### PR TITLE
[2022/07/05] facingMode 설정 및 기타

### DIFF
--- a/src/components/atoms/Video.js
+++ b/src/components/atoms/Video.js
@@ -3,8 +3,24 @@ import Webcam from "react-webcam";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
-function Video(props, ref) {
-  return <StyledVideo autoPlay muted playsInline ref={ref} />;
+function Video({ facingMode }, ref) {
+  const VideoConfig =
+    facingMode === "user"
+      ? { facingMode: "user" }
+      : { facingMode: { exact: "environment" } };
+  const videoConstraints = {
+    facingMode: VideoConfig,
+  };
+
+  return (
+    <StyledVideo
+      autoPlay
+      muted
+      playsInline
+      videoConstraints={videoConstraints}
+      ref={ref}
+    />
+  );
 }
 
 export default forwardRef(Video);
@@ -20,6 +36,7 @@ const StyledVideo = styled(Webcam)`
 `;
 
 Video.propTypes = {
+  facingMode: PropTypes.string,
   ref: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.elementType }),

--- a/src/components/organisms/PracticeListContent.js
+++ b/src/components/organisms/PracticeListContent.js
@@ -62,6 +62,5 @@ const Wrapper = styled.div`
 `;
 
 PracticeListContent.propTypes = {
-  description: PropTypes.string,
-  data: PropTypes.array,
+  data: PropTypes.object,
 };

--- a/src/components/organisms/VideoContent.js
+++ b/src/components/organisms/VideoContent.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
@@ -6,6 +6,9 @@ import Video from "../atoms/Video";
 
 function VideoContent() {
   const videoRef = useRef(null);
+  const [videoConstraints, setVideoConstraints] = useState({
+    facingMode: "user",
+  });
 
   return <Video ref={videoRef} />;
 }

--- a/src/components/organisms/VideoContent.js
+++ b/src/components/organisms/VideoContent.js
@@ -3,14 +3,37 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 import Video from "../atoms/Video";
+import Button from "../atoms/Button";
 
 function VideoContent() {
   const videoRef = useRef(null);
-  const [videoConstraints, setVideoConstraints] = useState({
-    facingMode: "user",
-  });
+  const [facingMode, setFacingMode] = useState("user");
 
-  return <Video ref={videoRef} />;
+  const handleFacingModeChange = () => {
+    switch (facingMode) {
+      case "user":
+        setFacingMode("environment");
+        break;
+      case "environment":
+        setFacingMode("user");
+        break;
+    }
+  };
+
+  return (
+    <Container>
+      <Button className="small" onClick={handleFacingModeChange}>
+        카메라 전환
+      </Button>
+      <Video facingMode={facingMode} ref={videoRef} />
+    </Container>
+  );
 }
 
 export default VideoContent;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`;

--- a/src/pages/Practice/index.js
+++ b/src/pages/Practice/index.js
@@ -19,7 +19,6 @@ export default Practice;
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
## 주제
- facingMode 설정
- 기타 (CSS 수정 및 proptype 삭제)

### 주요 작업사항
**facingMode 설정**
모바일 용 카메라 전환을 위한 facingMode 설정을 추가하였습니다.

```
  const [facingMode, setFacingMode] = useState("user");

  const handleFacingModeChange = () => {
    switch (facingMode) {
      case "user":
        setFacingMode("environment");
        break;
      case "environment":
        setFacingMode("user");
        break;
    }
  };
```

카메라 전환에 대한 기능을 이미지로 웹캠 위에 삽입하려고 하였으나, 생각보다 시간이 오래걸려
버튼으로 변경하였으며 추후 리팩토링 시간에 변경하고자 합니다.

**기타 (CSS 수정 및 proptype 삭제)**
- Practice:   justify-content: center 삭제
- PracteListContent: description: PropTypes.string 삭제

## 기타
아직 relative와 absoulte의 개념이 명확하지 않아 이미지를 위치 시키는 작업이 어렵습니다.
기능 먼저 빠르게 구현하고 CSS를 다듬어야 할 것 같습니다. 