### PR TITLE
[2022/07/05] facingMode 잘못된 로직 수정 및 일부 CSS 수정

### DIFF
--- a/src/components/atoms/Video.js
+++ b/src/components/atoms/Video.js
@@ -4,20 +4,17 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 function Video({ facingMode }, ref) {
-  const VideoConfig =
+  const videoConfig =
     facingMode === "user"
       ? { facingMode: "user" }
       : { facingMode: { exact: "environment" } };
-  const videoConstraints = {
-    facingMode: VideoConfig,
-  };
 
   return (
     <StyledVideo
       autoPlay
       muted
       playsInline
-      videoConstraints={videoConstraints}
+      videoConstraints={videoConfig}
       ref={ref}
     />
   );

--- a/src/pages/Practice/PracticeDetail.js
+++ b/src/pages/Practice/PracticeDetail.js
@@ -44,8 +44,8 @@ const Wrapper = styled.div`
 
 const TextWrapper = styled.div`
   width: 86vw;
-  height: 10vh;
-  line-height: 10vh;
+  height: 8vh;
+  line-height: 8vh;
   text-align: center;
   border: 1px solid black;
 `;
@@ -55,7 +55,7 @@ const ImageBox = styled.div`
   justify-content: center;
   width: 40vw;
   height: 20vh;
-  margin: 1.5em 0;
+  margin: 1.2em 0;
   border: 1px solid black;
 `;
 


### PR DESCRIPTION
## 주제
- facingMode 잘못된 로직 수정
- 일부 CSS 수정

### 주요 작업사항
**facingMode 잘못된 로직 수정**
Video 컴포넌트에서 facingMode에 대한 설정을 잘못된 형식으로 전달하여,
올바른 형식으로 전달될 수 있도록 불필요한 코드를 삭제하였습니다. 

```
  const videoConfig =
    facingMode === "user"
      ? { facingMode: "user" }
      : { facingMode: { exact: "environment" } };
```

**일부 CSS 수정**
- PracticeDetail:   TextWrapper height을 10vh에서 8vh로 수정, margin을 1.5em에서 1.2em으로 수정