### PR TITLE
[2022/07/06] fingerpose 라이브러리 추가, 한글 자음 제스처 등록 및 제스처 예측 로직 작성

### DIFF
--- a/src/common/Fingerpose/FingerDescription.js
+++ b/src/common/Fingerpose/FingerDescription.js
@@ -1,0 +1,126 @@
+const Handedness = {
+  Left: "Left",
+  Right: "Right",
+};
+
+const Finger = {
+  Thumb: 0,
+  Index: 1,
+  Middle: 2,
+  Ring: 3,
+  Pinky: 4,
+
+  // just for convenience
+  all: [0, 1, 2, 3, 4],
+
+  nameMapping: {
+    0: "Thumb",
+    1: "Index",
+    2: "Middle",
+    3: "Ring",
+    4: "Pinky",
+  },
+
+  // Describes mapping of joints based on the 21 points returned by handpose.
+  // Handpose indexes are defined as follows:
+  // (all fingers use last index as "finger tip")
+  // ---------------------------------------------------------------------------
+  // [0]     Palm
+  // [1-4]   Thumb
+  // [5-8]   Index
+  // [9-12]  Middle
+  // [13-16] Ring
+  // [17-20] Pinky
+  pointsMapping: {
+    0: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+    ],
+    1: [
+      [0, 5],
+      [5, 6],
+      [6, 7],
+      [7, 8],
+    ],
+    2: [
+      [0, 9],
+      [9, 10],
+      [10, 11],
+      [11, 12],
+    ],
+    3: [
+      [0, 13],
+      [13, 14],
+      [14, 15],
+      [15, 16],
+    ],
+    4: [
+      [0, 17],
+      [17, 18],
+      [18, 19],
+      [19, 20],
+    ],
+  },
+
+  getName: function (value) {
+    return typeof this.nameMapping[value] !== "undefined"
+      ? this.nameMapping[value]
+      : false;
+  },
+
+  getPoints: function (value) {
+    return typeof this.pointsMapping[value] !== "undefined"
+      ? this.pointsMapping[value]
+      : false;
+  },
+};
+
+const FingerCurl = {
+  NoCurl: 0,
+  HalfCurl: 1,
+  FullCurl: 2,
+
+  nameMapping: {
+    0: "No Curl",
+    1: "Half Curl",
+    2: "Full Curl",
+  },
+
+  getName: function (value) {
+    return typeof this.nameMapping[value] !== "undefined"
+      ? this.nameMapping[value]
+      : false;
+  },
+};
+
+const FingerDirection = {
+  VerticalUp: 0,
+  VerticalDown: 1,
+  HorizontalLeft: 2,
+  HorizontalRight: 3,
+  DiagonalUpRight: 4,
+  DiagonalUpLeft: 5,
+  DiagonalDownRight: 6,
+  DiagonalDownLeft: 7,
+
+  nameMapping: {
+    0: "Vertical Up",
+    1: "Vertical Down",
+    2: "Horizontal Left",
+    3: "Horizontal Right",
+    4: "Diagonal Up Right",
+    5: "Diagonal Up Left",
+    6: "Diagonal Down Right",
+    7: "Diagonal Down Left",
+  },
+
+  getName: function (value) {
+    return typeof this.nameMapping[value] !== "undefined"
+      ? this.nameMapping[value]
+      : false;
+  },
+};
+
+export { Handedness, Finger, FingerCurl, FingerDirection };

--- a/src/common/Fingerpose/FingerPoseEstimator.js
+++ b/src/common/Fingerpose/FingerPoseEstimator.js
@@ -1,0 +1,401 @@
+/* eslint-disable no-unused-expressions */
+
+import { Finger, FingerCurl, FingerDirection } from "./FingerDescription";
+
+export default class FingerPoseEstimator {
+  constructor(options) {
+    this.options = {
+      ...{
+        // curl estimation
+        HALF_CURL_START_LIMIT: 60.0,
+        NO_CURL_START_LIMIT: 130.0,
+
+        // direction estimation
+        DISTANCE_VOTE_POWER: 1.1,
+        SINGLE_ANGLE_VOTE_POWER: 0.9,
+        TOTAL_ANGLE_VOTE_POWER: 1.6,
+      },
+      ...options,
+    };
+  }
+
+  estimate(landmarks) {
+    // step 1: calculate slopes
+
+    let slopesXY = [];
+    let slopesYZ = [];
+
+    for (let finger of Finger.all) {
+      let points = Finger.getPoints(finger);
+      let slopeAtXY = [];
+      let slopeAtYZ = [];
+
+      for (let point of points) {
+        let point1 = landmarks[point[0]];
+        let point2 = landmarks[point[1]];
+
+        // calculate single slope
+        let slopes = this.getSlopes(point1, point2);
+        let slopeXY = slopes[0];
+        let slopeYZ = slopes[1];
+        slopeAtXY.push(slopeXY);
+        slopeAtYZ.push(slopeYZ);
+      }
+
+      slopesXY.push(slopeAtXY);
+      slopesYZ.push(slopeAtYZ);
+    }
+
+    // step 2: calculate orientations
+
+    let fingerCurls = [];
+    let fingerDirections = [];
+
+    for (let finger of Finger.all) {
+      // start finger predictions from palm - except for thumb
+      let pointIndexAt = finger == Finger.Thumb ? 1 : 0;
+
+      let fingerPointsAt = Finger.getPoints(finger);
+      let startPoint = landmarks[fingerPointsAt[pointIndexAt][0]];
+      let midPoint = landmarks[fingerPointsAt[pointIndexAt + 1][1]];
+      let endPoint = landmarks[fingerPointsAt[3][1]];
+
+      // check if finger is curled
+      let fingerCurled = this.estimateFingerCurl(
+        startPoint,
+        midPoint,
+        endPoint,
+      );
+
+      let fingerPosition = this.calculateFingerDirection(
+        startPoint,
+        midPoint,
+        endPoint,
+        slopesXY[finger].slice(pointIndexAt),
+      );
+
+      fingerCurls[finger] = fingerCurled;
+      fingerDirections[finger] = fingerPosition;
+    }
+
+    return { curls: fingerCurls, directions: fingerDirections };
+  }
+
+  // point1, point2 are 2d or 3d point arrays (xy[z])
+  // returns either a single scalar (2d) or array of two slopes (3d)
+  getSlopes(point1, point2) {
+    let slopeXY = this.calculateSlope(point1.x, point1.y, point2.x, point2.y); // xy면과 방향의 각도
+    if (point1.length == 2) {
+      return slopeXY;
+    }
+
+    let slopeYZ = this.calculateSlope(point1.y, point1.z, point2.y, point2.z); // yz면과 방향의 각도
+    return [slopeXY, slopeYZ];
+  }
+
+  angleOrientationAt(angle, weightageAt = 1.0) {
+    let isVertical = 0;
+    let isDiagonal = 0;
+    let isHorizontal = 0;
+
+    if (angle >= 75.0 && angle <= 105.0) {
+      isVertical = 1 * weightageAt;
+    } else if (angle >= 25.0 && angle <= 155.0) {
+      isDiagonal = 1 * weightageAt;
+    } else {
+      isHorizontal = 1 * weightageAt;
+    }
+
+    return [isVertical, isDiagonal, isHorizontal];
+  }
+
+  estimateFingerCurl(startPoint, midPoint, endPoint) {
+    // startPoint - 0 & wrist, midPoint - 6 & pip, endPoint - 8 & tip
+    let start_mid_x_dist = startPoint.x - midPoint.x;
+    let start_end_x_dist = startPoint.x - endPoint.x;
+    let mid_end_x_dist = midPoint.x - endPoint.x;
+
+    let start_mid_y_dist = startPoint.y - midPoint.y;
+    let start_end_y_dist = startPoint.y - endPoint.y;
+    let mid_end_y_dist = midPoint.y - endPoint.y;
+
+    let start_mid_z_dist = startPoint.z - midPoint.z;
+    let start_end_z_dist = startPoint.z - endPoint.z;
+    let mid_end_z_dist = midPoint.z - endPoint.z;
+
+    let start_mid_dist = Math.sqrt(
+      //ab - wrist to index-finger-pip
+      start_mid_x_dist * start_mid_x_dist +
+        start_mid_y_dist * start_mid_y_dist +
+        start_mid_z_dist * start_mid_z_dist,
+    );
+    let start_end_dist = Math.sqrt(
+      //ac - wrist to index-finger-tip
+      start_end_x_dist * start_end_x_dist +
+        start_end_y_dist * start_end_y_dist +
+        start_end_z_dist * start_end_z_dist,
+    );
+    let mid_end_dist = Math.sqrt(
+      //bc - index-finger-pip to index-finger-tip
+      mid_end_x_dist * mid_end_x_dist +
+        mid_end_y_dist * mid_end_y_dist +
+        mid_end_z_dist * mid_end_z_dist,
+    );
+
+    let cos_in =
+      // 코사인 제 2법칙
+      (mid_end_dist * mid_end_dist +
+        start_mid_dist * start_mid_dist -
+        start_end_dist * start_end_dist) /
+      (2 * mid_end_dist * start_mid_dist);
+
+    if (cos_in > 1.0) {
+      cos_in = 1.0;
+    } else if (cos_in < -1.0) {
+      cos_in = -1.0;
+    }
+
+    let angleOfCurve = Math.acos(cos_in); // COS값을 arc cosin을 이용하여 degree을 구함
+    angleOfCurve = (57.2958 * angleOfCurve) % 180; // degree으로 radian를 구함
+
+    let fingerCurl;
+    if (angleOfCurve > this.options.NO_CURL_START_LIMIT) {
+      //130
+      fingerCurl = FingerCurl.NoCurl;
+    } else if (angleOfCurve > this.options.HALF_CURL_START_LIMIT) {
+      // 60
+      fingerCurl = FingerCurl.HalfCurl;
+    } else {
+      fingerCurl = FingerCurl.FullCurl;
+    }
+
+    return fingerCurl;
+  }
+
+  estimateHorizontalDirection(
+    start_end_x_dist,
+    start_mid_x_dist,
+    mid_end_x_dist,
+    max_dist_x,
+  ) {
+    let estimatedDirection;
+    if (max_dist_x == Math.abs(start_end_x_dist)) {
+      if (start_end_x_dist > 0) {
+        estimatedDirection = FingerDirection.HorizontalLeft;
+      } else {
+        estimatedDirection = FingerDirection.HorizontalRight;
+      }
+    } else if (max_dist_x == Math.abs(start_mid_x_dist)) {
+      if (start_mid_x_dist > 0) {
+        estimatedDirection = FingerDirection.HorizontalLeft;
+      } else {
+        estimatedDirection = FingerDirection.HorizontalRight;
+      }
+    } else {
+      if (mid_end_x_dist > 0) {
+        estimatedDirection = FingerDirection.HorizontalLeft;
+      } else {
+        estimatedDirection = FingerDirection.HorizontalRight;
+      }
+    }
+
+    return estimatedDirection;
+  }
+
+  estimateVerticalDirection(
+    start_end_y_dist,
+    start_mid_y_dist,
+    mid_end_y_dist,
+    max_dist_y,
+  ) {
+    let estimatedDirection;
+    if (max_dist_y == Math.abs(start_end_y_dist)) {
+      if (start_end_y_dist < 0) {
+        estimatedDirection = FingerDirection.VerticalDown;
+      } else {
+        estimatedDirection = FingerDirection.VerticalUp;
+      }
+    } else if (max_dist_y == Math.abs(start_mid_y_dist)) {
+      if (start_mid_y_dist < 0) {
+        estimatedDirection = FingerDirection.VerticalDown;
+      } else {
+        estimatedDirection = FingerDirection.VerticalUp;
+      }
+    } else {
+      if (mid_end_y_dist < 0) {
+        estimatedDirection = FingerDirection.VerticalDown;
+      } else {
+        estimatedDirection = FingerDirection.VerticalUp;
+      }
+    }
+
+    return estimatedDirection;
+  }
+
+  estimateDiagonalDirection(
+    start_end_y_dist,
+    start_mid_y_dist,
+    mid_end_y_dist,
+    max_dist_y,
+    start_end_x_dist,
+    start_mid_x_dist,
+    mid_end_x_dist,
+    max_dist_x,
+  ) {
+    let estimatedDirection;
+    let reqd_vertical_direction = this.estimateVerticalDirection(
+      start_end_y_dist,
+      start_mid_y_dist,
+      mid_end_y_dist,
+      max_dist_y,
+    );
+    let reqd_horizontal_direction = this.estimateHorizontalDirection(
+      start_end_x_dist,
+      start_mid_x_dist,
+      mid_end_x_dist,
+      max_dist_x,
+    );
+
+    if (reqd_vertical_direction == FingerDirection.VerticalUp) {
+      if (reqd_horizontal_direction == FingerDirection.HorizontalLeft) {
+        estimatedDirection = FingerDirection.DiagonalUpLeft;
+      } else {
+        estimatedDirection = FingerDirection.DiagonalUpRight;
+      }
+    } else {
+      if (reqd_horizontal_direction == FingerDirection.HorizontalLeft) {
+        estimatedDirection = FingerDirection.DiagonalDownLeft;
+      } else {
+        estimatedDirection = FingerDirection.DiagonalDownRight;
+      }
+    }
+
+    return estimatedDirection;
+  }
+
+  calculateFingerDirection(startPoint, midPoint, endPoint, fingerSlopes) {
+    let start_mid_x_dist = startPoint.x - midPoint.x;
+    let start_end_x_dist = startPoint.x - endPoint.x;
+    let mid_end_x_dist = midPoint.x - endPoint.x;
+
+    let start_mid_y_dist = startPoint.y - midPoint.y;
+    let start_end_y_dist = startPoint.y - endPoint.y;
+    let mid_end_y_dist = midPoint.y - endPoint.y;
+
+    let max_dist_x = Math.max(
+      // x 좌표 기준으로 거리가 가장 큰 값
+      Math.abs(start_mid_x_dist),
+      Math.abs(start_end_x_dist),
+      Math.abs(mid_end_x_dist),
+    );
+    let max_dist_y = Math.max(
+      // y 좌표 기준으로 거리가 가장 큰 값
+      Math.abs(start_mid_y_dist),
+      Math.abs(start_end_y_dist),
+      Math.abs(mid_end_y_dist),
+    );
+
+    let voteVertical = 0.0; // 수직
+    let voteDiagonal = 0.0; // 대각선
+    let voteHorizontal = 0.0; // 수평
+
+    let start_end_x_y_dist_ratio = max_dist_y / (max_dist_x + 0.00001);
+    if (start_end_x_y_dist_ratio > 1.5) {
+      voteVertical += this.options.DISTANCE_VOTE_POWER;
+    } else if (start_end_x_y_dist_ratio > 0.66) {
+      voteDiagonal += this.options.DISTANCE_VOTE_POWER;
+    } else {
+      voteHorizontal += this.options.DISTANCE_VOTE_POWER;
+    }
+
+    let start_mid_dist = Math.sqrt(
+      start_mid_x_dist * start_mid_x_dist + start_mid_y_dist * start_mid_y_dist,
+    );
+    let start_end_dist = Math.sqrt(
+      start_end_x_dist * start_end_x_dist + start_end_y_dist * start_end_y_dist,
+    );
+    let mid_end_dist = Math.sqrt(
+      mid_end_x_dist * mid_end_x_dist + mid_end_y_dist * mid_end_y_dist,
+    );
+
+    let max_dist = Math.max(start_mid_dist, start_end_dist, mid_end_dist);
+    let calc_start_point_x = startPoint[0];
+    let calc_start_point_y = startPoint[1];
+    let calc_end_point_x = endPoint[0];
+    let calc_end_point_y = endPoint[1];
+
+    if (max_dist == start_mid_dist) {
+      (calc_end_point_x = endPoint[0]), (calc_end_point_y = endPoint[1]);
+    } else if (max_dist == mid_end_dist) {
+      (calc_start_point_x = midPoint[0]), (calc_start_point_y = midPoint[1]);
+    }
+
+    let calcStartPoint = [calc_start_point_x, calc_start_point_y];
+    let calcEndPoint = [calc_end_point_x, calc_end_point_y];
+
+    let totalAngle = this.getSlopes(calcStartPoint, calcEndPoint);
+    let votes = this.angleOrientationAt(
+      totalAngle,
+      this.options.TOTAL_ANGLE_VOTE_POWER,
+    );
+    voteVertical += votes[0];
+    voteDiagonal += votes[1];
+    voteHorizontal += votes[2];
+
+    for (let fingerSlope of fingerSlopes) {
+      let votes = this.angleOrientationAt(
+        fingerSlope,
+        this.options.SINGLE_ANGLE_VOTE_POWER,
+      );
+      voteVertical += votes[0];
+      voteDiagonal += votes[1];
+      voteHorizontal += votes[2];
+    }
+
+    // in case of tie, highest preference goes to Vertical,
+    // followed by horizontal and then diagonal
+    let estimatedDirection;
+    if (voteVertical == Math.max(voteVertical, voteDiagonal, voteHorizontal)) {
+      estimatedDirection = this.estimateVerticalDirection(
+        start_end_y_dist,
+        start_mid_y_dist,
+        mid_end_y_dist,
+        max_dist_y,
+      );
+    } else if (voteHorizontal == Math.max(voteDiagonal, voteHorizontal)) {
+      estimatedDirection = this.estimateHorizontalDirection(
+        start_end_x_dist,
+        start_mid_x_dist,
+        mid_end_x_dist,
+        max_dist_x,
+      );
+    } else {
+      estimatedDirection = this.estimateDiagonalDirection(
+        start_end_y_dist,
+        start_mid_y_dist,
+        mid_end_y_dist,
+        max_dist_y,
+        start_end_x_dist,
+        start_mid_x_dist,
+        mid_end_x_dist,
+        max_dist_x,
+      );
+    }
+
+    return estimatedDirection;
+  }
+
+  calculateSlope(point1x, point1y, point2x, point2y) {
+    let value = (point1y - point2y) / (point1x - point2x); // tan 구하기
+    let slope = (Math.atan(value) * 180) / Math.PI; // arc tan을 이용하여 각도 구하고 radian을 구함
+
+    if (slope <= 0) {
+      // 음수면 양수로 변경 (절대값)
+      slope = -slope;
+    } else if (slope > 0) {
+      slope = 180 - slope;
+    }
+
+    return slope;
+  }
+}

--- a/src/common/Fingerpose/GestureDescription.js
+++ b/src/common/Fingerpose/GestureDescription.js
@@ -1,0 +1,114 @@
+export default class GestureDescription {
+  constructor(name) {
+    // name (should be unique)
+    this.name = name;
+
+    // gesture as described by curls / directions
+    this.curls = {};
+    this.directions = {};
+  }
+
+  addCurl(handedness, finger, curl, contrib = 1.0) {
+    if (!this.curls[handedness]?.[finger]) {
+      this.curls[handedness] = {
+        ...this.curls[handedness],
+        [finger]: [[curl, contrib]],
+      };
+    } else {
+      this.curls[handedness] = {
+        ...this.curls[handedness],
+        [finger]: [...this.curls[handedness][finger], [curl, contrib]],
+      };
+    }
+  }
+
+  addDirection(handedness, finger, position, contrib = 1.0) {
+    if (!this.directions[handedness]?.[finger]) {
+      this.directions[handedness] = {
+        ...this.directions[handedness],
+        [finger]: [[position, contrib]],
+      };
+    } else {
+      this.directions[handedness] = {
+        ...this.directions[handedness],
+        [finger]: [...this.directions[handedness][finger], [position, contrib]],
+      };
+    }
+  }
+
+  matchAgainst(detectedHandedness, detectedCurls, detectedDirections) {
+    let score = 0.0;
+    let numParameters = 0;
+
+    // look at the detected curl of each finger and compare with
+    // the expected curl of this finger inside current gesture
+    for (let fingerIdx in detectedCurls) {
+      let detectedCurl = detectedCurls[fingerIdx];
+      let expectedCurls = this.curls?.[detectedHandedness]?.[fingerIdx];
+
+      if (typeof expectedCurls === "undefined") {
+        // no curl description available for this finger
+        // => no contribution to the final score
+        continue;
+      }
+
+      // increase the number of relevant parameters
+      numParameters++;
+
+      // compare to each possible curl of this specific finger
+      let matchingCurlFound = false;
+      let highestCurlContrib = 0;
+      for (const [expectedCurl, contrib] of expectedCurls) {
+        if (detectedCurl == expectedCurl) {
+          score += contrib;
+          highestCurlContrib = Math.max(highestCurlContrib, contrib);
+          matchingCurlFound = true;
+          break;
+        }
+      }
+
+      // subtract penalty if curl was expected but not found
+      if (!matchingCurlFound) {
+        score -= highestCurlContrib;
+      }
+    }
+
+    // same for detected direction of each finger
+    for (let fingerIdx in detectedDirections) {
+      let detectedDirection = detectedDirections[fingerIdx];
+      let expectedDirections =
+        this.directions?.[detectedHandedness]?.[fingerIdx];
+
+      if (typeof expectedDirections === "undefined") {
+        // no direction description available for this finger
+        // => no contribution to the final score
+        continue;
+      }
+
+      // increase the number of relevant parameters
+      numParameters++;
+
+      // compare to each possible direction of this specific finger
+      let matchingDirectionFound = false;
+      let highestDirectionContrib = 0;
+      for (const [expectedDirection, contrib] of expectedDirections) {
+        if (detectedDirection == expectedDirection) {
+          score += contrib;
+          highestDirectionContrib = Math.max(highestDirectionContrib, contrib);
+          matchingDirectionFound = true;
+          break;
+        }
+      }
+
+      // subtract penalty if direction was expected but not found
+      if (!matchingDirectionFound) {
+        score -= highestDirectionContrib;
+      }
+    }
+
+    // multiply final score with 10 (to maintain compatibility)
+    let finalScore = (score / numParameters) * 10;
+
+    return finalScore;
+  }
+}

--- a/src/common/Fingerpose/GestureEstimator.js
+++ b/src/common/Fingerpose/GestureEstimator.js
@@ -1,0 +1,66 @@
+import FingerPoseEstimator from "./FingerPoseEstimator";
+import { Finger, FingerCurl, FingerDirection } from "./FingerDescription";
+
+export default class GestureEstimator {
+  constructor(knownGestures, estimatorOptions = {}) {
+    this.estimator = new FingerPoseEstimator(estimatorOptions);
+
+    // list of predefined gestures
+    this.gestures = knownGestures;
+  }
+
+  estimate(landmarks, minScore) {
+    // step 1: get estimations of curl / direction for each finger
+    const hands = [];
+
+    for (let landmark of landmarks) {
+      const estimation = this.estimator.estimate(landmark.keypoints3D);
+      const handData = {
+        handedness: landmark.handedness,
+        curls: estimation.curls,
+        directions: estimation.directions,
+      };
+      hands.push(handData);
+    }
+
+    const gestureData = [];
+
+    for (let hand of hands) {
+      let poseData = [];
+      let gesturesFound = [];
+
+      for (let fingerIdx of Finger.all) {
+        poseData.push([
+          Finger.getName(fingerIdx),
+          FingerCurl.getName(hand.curls[fingerIdx]),
+          FingerDirection.getName(hand.directions[fingerIdx]),
+        ]);
+      }
+
+      // step 2: compare gesture description to each known gesture
+      for (let gesture of this.gestures) {
+        let score = gesture.matchAgainst(
+          hand.handedness,
+          hand.curls,
+          hand.directions,
+        );
+
+        if (score >= minScore) {
+          gesturesFound.push({
+            name: gesture.name,
+            score: score,
+            numberOfHands: Object.keys(gesture.curls).length,
+          });
+        }
+      }
+
+      gestureData.push({
+        handness: hand.handedness,
+        poseData: poseData,
+        gestures: gesturesFound,
+      });
+    }
+
+    return gestureData;
+  }
+}

--- a/src/common/Fingerpose/GestureEstimator.js
+++ b/src/common/Fingerpose/GestureEstimator.js
@@ -1,5 +1,6 @@
 import FingerPoseEstimator from "./FingerPoseEstimator";
 import { Finger, FingerCurl, FingerDirection } from "./FingerDescription";
+import { copyModel } from "@tensorflow/tfjs-core/dist/io/model_management";
 
 export default class GestureEstimator {
   constructor(knownGestures, estimatorOptions = {}) {

--- a/src/common/Fingerpose/Gestures/Hello.js
+++ b/src/common/Fingerpose/Gestures/Hello.js
@@ -1,0 +1,168 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../FingerDescription";
+import GestureDescription from "../GestureDescription";
+
+// describe victory gesture ✌️
+const hello = new GestureDescription("hello");
+
+// thumb:
+hello.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+// index:
+hello.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+// middle:
+hello.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+// ring:
+hello.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.9);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.DiagonalUpRight,
+  0.9,
+);
+
+// pinky:
+hello.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  0.9,
+);
+
+// thumb:
+hello.addDirection(
+  Handedness.Right,
+  Finger.Thumb,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Thumb,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+// index:
+hello.addCurl(Handedness.Right, Finger.Index, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Right, Finger.Index, FingerCurl.HalfCurl, 0.8);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+// middle:
+hello.addCurl(Handedness.Right, Finger.Middle, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Right, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+// ring:
+hello.addCurl(Handedness.Right, Finger.Ring, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Right, Finger.Ring, FingerCurl.HalfCurl, 0.9);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Ring,
+  FingerDirection.DiagonalUpRight,
+  0.9,
+);
+
+// pinky:
+hello.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+hello.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hello.addDirection(
+  Handedness.Right,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpRight,
+  0.9,
+);
+
+export default hello;

--- a/src/common/Fingerpose/Gestures/consonant/Bieup.js
+++ b/src/common/Fingerpose/Gestures/consonant/Bieup.js
@@ -1,0 +1,21 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const bieup = new GestureDescription("bieup");
+
+bieup.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+
+bieup.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+
+bieup.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+
+bieup.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+
+bieup.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+
+export default bieup;

--- a/src/common/Fingerpose/Gestures/consonant/Chieut.js
+++ b/src/common/Fingerpose/Gestures/consonant/Chieut.js
@@ -1,0 +1,60 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const chieut = new GestureDescription("chieut");
+
+chieut.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+chieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+chieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownRight,
+  0.8,
+);
+
+chieut.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+chieut.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalDownLeft,
+  1.0,
+);
+
+chieut.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+chieut.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.8);
+chieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalDownLeft,
+  1.0,
+);
+
+chieut.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default chieut;

--- a/src/common/Fingerpose/Gestures/consonant/Digeut.js
+++ b/src/common/Fingerpose/Gestures/consonant/Digeut.js
@@ -1,0 +1,35 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const diguet = new GestureDescription("diguet");
+
+diguet.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+diguet.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+diguet.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+diguet.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+diguet.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+diguet.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+diguet.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.8);
+
+diguet.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+diguet.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default diguet;

--- a/src/common/Fingerpose/Gestures/consonant/Giyeok.js
+++ b/src/common/Fingerpose/Gestures/consonant/Giyeok.js
@@ -1,0 +1,41 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const giyeok = new GestureDescription("giyeok");
+
+giyeok.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+giyeok.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalLeft,
+  0.8,
+);
+// giyeok.addDirection(Finger.Index, FingerDirection.HorizontalRight, 0.8);
+giyeok.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownLeft,
+  0.8,
+);
+
+giyeok.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+giyeok.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.7);
+giyeok.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  0.8,
+);
+
+giyeok.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+
+giyeok.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+giyeok.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default giyeok;

--- a/src/common/Fingerpose/Gestures/consonant/Hieut.js
+++ b/src/common/Fingerpose/Gestures/consonant/Hieut.js
@@ -1,0 +1,65 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const hieut = new GestureDescription("hieut");
+
+// thumb:
+// - curl: none (must)
+// - direction vertical up (best)
+// - direction diagonal up left / right (acceptable)
+hieut.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.DiagonalUpRight,
+  0.9,
+);
+
+// all other fingers:
+// - curled (best)
+// - half curled (acceptable)
+// - pointing down is NOT acceptable
+for (let finger of [Finger.Index, Finger.Middle, Finger.Ring, Finger.Pinky]) {
+  hieut.addCurl(Handedness.Left, finger, FingerCurl.FullCurl, 1.0);
+  hieut.addCurl(Handedness.Left, finger, FingerCurl.HalfCurl, 0.9);
+}
+
+// require the index finger to be somewhat left or right pointing
+// but NOT down and NOT fully up
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalLeft,
+  1.0,
+);
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+hieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+export default hieut;

--- a/src/common/Fingerpose/Gestures/consonant/Ieung.js
+++ b/src/common/Fingerpose/Gestures/consonant/Ieung.js
@@ -1,0 +1,52 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const ieung = new GestureDescription("ieung");
+
+ieung.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+ieung.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+ieung.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1.0);
+ieung.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+ieung.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+ieung.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+ieung.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+ieung.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+ieung.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+ieung.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+ieung.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+export default ieung;

--- a/src/common/Fingerpose/Gestures/consonant/Jieut.js
+++ b/src/common/Fingerpose/Gestures/consonant/Jieut.js
@@ -1,0 +1,53 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const jieut = new GestureDescription("jieut");
+
+jieut.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+jieut.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+jieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+jieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
+jieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+jieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownRight,
+  0.8,
+);
+
+jieut.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+jieut.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+jieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+jieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalDownLeft,
+  1.0,
+);
+
+jieut.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+jieut.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default jieut;

--- a/src/common/Fingerpose/Gestures/consonant/Kieuk.js
+++ b/src/common/Fingerpose/Gestures/consonant/Kieuk.js
@@ -1,0 +1,34 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const kiuek = new GestureDescription("kiuek");
+
+kiuek.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+kiuek.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+kiuek.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1.0);
+
+kiuek.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+kiuek.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+kiuek.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+
+kiuek.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+kiuek.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default kiuek;

--- a/src/common/Fingerpose/Gestures/consonant/Mieum.js
+++ b/src/common/Fingerpose/Gestures/consonant/Mieum.js
@@ -1,0 +1,46 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const miuem = new GestureDescription("miuem");
+
+miuem.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+
+miuem.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+miuem.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+miuem.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownRight,
+  0.8,
+);
+
+miuem.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1.0);
+miuem.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+miuem.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+miuem.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+miuem.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+miuem.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default miuem;

--- a/src/common/Fingerpose/Gestures/consonant/Nieun.js
+++ b/src/common/Fingerpose/Gestures/consonant/Nieun.js
@@ -1,0 +1,42 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const niuen = new GestureDescription("niuen");
+
+niuen.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+niuen.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+niuen.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+niuen.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+niuen.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+niuen.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+niuen.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+
+niuen.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+niuen.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.8);
+
+niuen.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+niuen.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default niuen;

--- a/src/common/Fingerpose/Gestures/consonant/Pieup.js
+++ b/src/common/Fingerpose/Gestures/consonant/Pieup.js
@@ -1,0 +1,48 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const pieup = new GestureDescription("pieup");
+
+pieup.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+pieup.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+pieup.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.HorizontalLeft,
+  1.0,
+);
+
+pieup.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+pieup.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+pieup.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
+pieup.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+pieup.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+pieup.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+pieup.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.8);
+
+pieup.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+pieup.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default pieup;

--- a/src/common/Fingerpose/Gestures/consonant/Riuel.js
+++ b/src/common/Fingerpose/Gestures/consonant/Riuel.js
@@ -1,0 +1,41 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const riuel = new GestureDescription("riuel");
+
+riuel.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+riuel.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+riuel.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+riuel.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+riuel.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+riuel.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+riuel.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
+riuel.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+riuel.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+riuel.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default riuel;

--- a/src/common/Fingerpose/Gestures/consonant/Siot.js
+++ b/src/common/Fingerpose/Gestures/consonant/Siot.js
@@ -1,0 +1,40 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const siot = new GestureDescription("siot");
+
+siot.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+siot.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+siot.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+siot.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownRight,
+  0.8,
+);
+
+siot.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+siot.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+siot.addDirection(
+  Handedness.Lefy,
+  Finger.Middle,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+
+siot.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+siot.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default siot;

--- a/src/common/Fingerpose/Gestures/consonant/Tieut.js
+++ b/src/common/Fingerpose/Gestures/consonant/Tieut.js
@@ -1,0 +1,47 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const tieut = new GestureDescription("tieut");
+
+tieut.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+tieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+tieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+tieut.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+tieut.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+tieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+tieut.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+tieut.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
+tieut.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+tieut.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+tieut.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default tieut;

--- a/src/common/Fingerpose/Gestures/consonant/index.js
+++ b/src/common/Fingerpose/Gestures/consonant/index.js
@@ -1,0 +1,33 @@
+import giyeok from "./Giyeok";
+import niuen from "./Nieun";
+import diguet from "./Digeut";
+import riuel from "./Riuel";
+import miuem from "./Mieum";
+import bieup from "./Bieup";
+import siot from "./Siot";
+import ieung from "./Ieung";
+import jieut from "./Jieut";
+import chieut from "./Chieut";
+import kiuek from "./Kieuk";
+import tieut from "./Tieut";
+import pieup from "./Pieup";
+import hieut from "./Hieut";
+
+const consonant = [
+  giyeok,
+  niuen,
+  diguet,
+  riuel,
+  miuem,
+  bieup,
+  siot,
+  ieung,
+  jieut,
+  chieut,
+  kiuek,
+  tieut,
+  pieup,
+  hieut,
+];
+
+export default consonant;

--- a/src/common/Fingerpose/Gestures/index.js
+++ b/src/common/Fingerpose/Gestures/index.js
@@ -1,0 +1,9 @@
+import hello from "./Hello";
+import giyeok from "./consonant/Giyeok";
+
+const Gestures = {
+  hello,
+  giyeok,
+};
+
+export default Gestures;

--- a/src/common/Fingerpose/Gestures/index.js
+++ b/src/common/Fingerpose/Gestures/index.js
@@ -1,9 +1,9 @@
 import hello from "./Hello";
-import giyeok from "./consonant/Giyeok";
+import Consonant from "./consonant";
 
 const Gestures = {
   hello,
-  giyeok,
+  Consonant,
 };
 
 export default Gestures;

--- a/src/common/Fingerpose/index.js
+++ b/src/common/Fingerpose/index.js
@@ -1,0 +1,10 @@
+import GestureEstimator from './GestureEstimator';
+import GestureDescription from './GestureDescription';
+import { Finger, FingerCurl, FingerDirection } from './FingerDescription';
+import Gestures from './Gestures/index';
+
+export default {
+  GestureEstimator, GestureDescription,
+  Finger, FingerCurl, FingerDirection,
+  Gestures
+};

--- a/src/common/Fingerpose/index.js
+++ b/src/common/Fingerpose/index.js
@@ -1,10 +1,4 @@
-import GestureEstimator from './GestureEstimator';
-import GestureDescription from './GestureDescription';
-import { Finger, FingerCurl, FingerDirection } from './FingerDescription';
-import Gestures from './Gestures/index';
+import GestureEstimator from "./GestureEstimator";
+import Gestures from "./Gestures/index";
 
-export default {
-  GestureEstimator, GestureDescription,
-  Finger, FingerCurl, FingerDirection,
-  Gestures
-};
+export { GestureEstimator, Gestures };

--- a/src/pages/Practice/PracticeDetail.js
+++ b/src/pages/Practice/PracticeDetail.js
@@ -4,6 +4,7 @@ import "@tensorflow/tfjs-core";
 import "@tensorflow/tfjs-backend-webgl";
 
 import { setHandDetector, drawHandKeypoints } from "../../common/utilities";
+import { GestureEstimator, Gestures } from "../../common/Fingerpose";
 
 import VideoContent from "../../components/organisms/VideoContent";
 import Image from "../../components/atoms/Image";
@@ -46,6 +47,41 @@ function PracticeDetail() {
 
       try {
         const hand = await detector.estimateHands(video);
+        const GE = new GestureEstimator(Gestures.Consonant);
+
+        if (hand.length > 0) {
+          const gesture = GE.estimate(hand, 7);
+          console.log(gesture);
+
+          const bestGesture = gesture.map((hand) => {
+            const score = hand.gestures.map((prediction) => prediction.score);
+            const maxScore = score.indexOf(Math.max(...score));
+
+            return hand.gestures[maxScore];
+          });
+
+          let gestureName = "";
+
+          if (gesture.length > 1) {
+            // 양손일 때
+
+            if (bestGesture[0]?.name === bestGesture[1]?.name) {
+              gestureName = bestGesture[0]?.name;
+            }
+          } else if (gesture.length === 1) {
+            // 한손 일 때
+            if (bestGesture.length) {
+              if (bestGesture[0]?.numberOfHands !== 1) {
+                gestureName = "두 손이 필요해";
+              } else {
+                gestureName = bestGesture[0].name;
+              }
+            } else {
+              gestureName = "감지된 제스처가 없어";
+            }
+          }
+          console.log("최종", gestureName);
+        }
 
         const ctx = canvasRef.current.getContext("2d");
         drawHandKeypoints(hand, ctx);


### PR DESCRIPTION
## 주제
- fingerpose 라이브러리 추가
- 한글 자음 제스처 등록
- 제스처 예측 로직 작성

### 주요 작업사항
**fingerpose 라이브러리 추가**
현재 fingerpose 라이브러리는 작년 handpose 모델 버전이며, 한 손만 감지하고 있습니다.
하여, 올해 버전의 hanpose 모델을 적용하고 두 손을 동시에 감지할 수 있도록 수정하였습니다. 

[모델]
작년 모델 - 배열 안의 중첩 배열 형태
올해 모델 - 배열 안의 객체 형태

[손 감지]
양 손 감지를 위해 제스처 등록 과정에서 handness 파라미터를 추가하였으며,  전체적으로 두 손에 대한 score을 계산할 수 있도록 수정하였습니다. (반복문 적용 등)

다만, 아쉬운 점은 기존 모델은 손 하나를 감지하기에 왼손, 오른손 여부 상관 없이 방향만 두 가지 설정하면 모두 감지할 수 있었는데, 지금은 양 손을 따로 탐지해야 하기에 두 손에 대한 코드를 2배로 작성해야 합니다. 


**한글 자음 제스처 등록**
복합 자음 제외 총 14개의 자음 제스처를 등록하였습니다.

![image](https://user-images.githubusercontent.com/94096095/177369147-bf8f986f-e278-4e2a-8d2e-bf9bb56c0b82.png)

현재 ㅁ과 ㅍ, ㄹ과 ㅌ 간의 손 모양이 비슷하여 정확한 구분을 하지 못하고 있습니다. (fingerpose 라이브러리 상 특정 수치를 기준으로 curl 및 direction을 구분해야 하여, 미세한 차이에 대한 정확한 구분이 어려움)

복합 자음의 경우 동일한 손 모양을 두 번 반복하는 지문자로, 현재 매 초마다 손가락을 탐지하는 로직에서는 구분이 어렵습니다.
우선 기본 기능을 먼저 개발 후 추후 고민해야 할 것 같습니다. 



**제스처 예측 로직 작성**
curl 및 direction의 기준으로 제스처를 구분하므로 비슷한 손 모양의 경우 여러 개의 제스처가 예측됩니다. 이 중 가장 높은 score을 기록한 제스처를 반환하도록 아래와 로직을 같이 작성하였습니다. 


```
          const bestGesture = gesture.map((hand) => {
            const score = hand.gestures.map((prediction) => prediction.score);
            const maxScore = score.indexOf(Math.max(...score));

            return hand.gestures[maxScore];
          });
```


