### PR TITLE
[2022/07/07] 알파벳 제스처 등록

### DIFF
--- a/src/common/Fingerpose/Gestures/alphabet/Asign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Asign.js
@@ -1,0 +1,60 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const aSign = new GestureDescription("A");
+
+//Thumb
+aSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+aSign.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+// aSign.addDirection(Finger.Index, FingerDirection.DiagonalUpLeft, 0.70);
+
+//Index
+aSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+aSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+aSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+// aSign.addDirection(Finger.Index, FingerDirection.DiagonalUpLeft, 0.70);
+
+//Middle
+aSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+aSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+// aSign.addDirection(Finger.Middle, FingerDirection.DiagonalUpLeft, 0.70);
+
+//Ring
+aSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+aSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+aSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default aSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Bsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Bsign.js
@@ -1,0 +1,50 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const bSign = new GestureDescription("B");
+
+//Thumb
+bSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+
+//Index
+bSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+bSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Middle
+bSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+bSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Ring
+bSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+bSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+bSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+bSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+export default bSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Csign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Csign.js
@@ -1,0 +1,90 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const cSign = new GestureDescription("C");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Ring",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Pinky",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ]
+//   ]
+
+//Thumb
+cSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Index
+cSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+cSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.9);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+cSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Ring
+cSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Pinky
+cSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 1);
+cSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+export default cSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Dsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Dsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const dSign = new GestureDescription("D");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+dSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+dSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Index
+dSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+dSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Middle
+dSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+dSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Ring
+dSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+dSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Pinky
+dSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+dSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+export default dSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Esign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Esign.js
@@ -1,0 +1,89 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const eSign = new GestureDescription("E");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+eSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Index
+eSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+eSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Ring
+eSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Pinky
+eSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 1);
+eSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+export default eSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Fsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Fsign.js
@@ -1,0 +1,89 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const fSign = new GestureDescription("F");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "No Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+fSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Index
+fSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+fSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Ring
+fSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+fSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+fSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+export default fSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Gsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Gsign.js
@@ -1,0 +1,66 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const gSign = new GestureDescription("G");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ]
+//   ]
+
+//Thumb
+gSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+gSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+//Index
+gSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+gSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
+gSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+//Middle
+gSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+
+//Ring
+gSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+//Pinky
+gSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default gSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Hsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Hsign.js
@@ -1,0 +1,85 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const hSign = new GestureDescription("H");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ]
+//   ]
+
+//Thumb
+hSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+hSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+//Index
+hSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+hSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
+hSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Middle
+hSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+hSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
+hSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Ring
+hSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+hSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+//Pinky
+hSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+hSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+export default hSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Isign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Isign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const iSign = new GestureDescription("I");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "No Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+iSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+iSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Index
+iSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+iSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Middle
+iSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+iSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Ring
+iSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+iSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Pinky
+iSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+iSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+export default iSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Jsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Jsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const jSign = new GestureDescription("J");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Pinky",
+//       "No Curl",
+//       "Horizontal Right"
+//     ]
+//   ]
+
+//Thumb
+jSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+jSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Index
+jSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+jSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+jSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+jSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Ring
+jSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+jSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Pinky
+jSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+jSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+export default jSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Ksign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Ksign.js
@@ -1,0 +1,95 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const kSign = new GestureDescription("K");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+kSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Index
+kSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+kSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Ring
+kSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+kSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+kSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+export default kSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Lsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Lsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const lSign = new GestureDescription("L");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+lSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+lSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+//Index
+lSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+lSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Middle
+lSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+lSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Ring
+lSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+lSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Pinky
+lSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+lSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+export default lSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Msign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Msign.js
@@ -1,0 +1,89 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const mSign = new GestureDescription("M");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+mSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Index
+mSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Middle
+mSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Ring
+mSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+mSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+mSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+export default mSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Nsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Nsign.js
@@ -1,0 +1,77 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const nSign = new GestureDescription("N");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+nSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+nSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+//Index
+nSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+nSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+nSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+nSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+
+//Ring
+nSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+//Pinky
+nSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+nSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+export default nSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Osign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Osign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const oSign = new GestureDescription("O");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Ring",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Pinky",
+//       "Half Curl",
+//       "Diagonal Up Right"
+//     ]
+//   ]
+
+//Thumb
+oSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+oSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Index
+oSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1);
+oSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+oSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
+oSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Ring
+oSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
+oSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Pinky
+oSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 1);
+oSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+export default oSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Psign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Psign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const pSign = new GestureDescription("P");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Horizontal Right"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Down Right"
+//     ]
+//   ]
+
+//Thumb
+pSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+pSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+//Index
+pSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+pSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalRight,
+  1.0,
+);
+
+//Middle
+pSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
+pSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalDownRight,
+  1.0,
+);
+
+//Ring
+pSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+pSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.DiagonalDownRight,
+  1.0,
+);
+
+//Pinky
+pSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+pSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalDownRight,
+  1.0,
+);
+
+export default pSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Qsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Qsign.js
@@ -1,0 +1,71 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const qSign = new GestureDescription("Q");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Vertical Down"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Vertical Down"
+//     ],
+//     [
+//       "Middle",
+//       "Half Curl",
+//       "Vertical Down"
+//     ],
+//     [
+//       "Ring",
+//       "Half Curl",
+//       "Vertical Down"
+//     ],
+//     [
+//       "Pinky",
+//       "Half Curl",
+//       "Diagonal Down Left"
+//     ]
+//   ]
+
+//Thumb
+qSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+qSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+qSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalDownRight,
+  1.0,
+);
+
+//Index
+qSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1);
+qSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalDown,
+  1.0,
+);
+
+//Middle
+qSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+
+//Ring
+qSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+//Pinky
+qSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default qSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Rsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Rsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const rSign = new GestureDescription("R");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+rSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+rSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Index
+rSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+rSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Middle
+rSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+rSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Ring
+rSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+rSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Pinky
+rSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+rSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+export default rSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Ssign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Ssign.js
@@ -1,0 +1,101 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const sSign = new GestureDescription("S");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+sSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Index
+sSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+//Middle
+sSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Ring
+sSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Pinky
+sSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+sSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+export default sSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Tsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Tsign.js
@@ -1,0 +1,89 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const tSign = new GestureDescription("T");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+tSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Index
+tSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+//Middle
+tSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Ring
+tSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+//Pinky
+tSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+tSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.HorizontalRight,
+  0.8,
+);
+
+export default tSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Usign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Usign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const uSign = new GestureDescription("U");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+uSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+uSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.8,
+);
+
+//Index
+uSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+uSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Middle
+uSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+uSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Ring
+uSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+uSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Pinky
+uSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+uSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpRight,
+  0.8,
+);
+
+export default uSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Vsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Vsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const vSign = new GestureDescription("V");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+vSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+vSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.7,
+);
+
+//Index
+vSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+vSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.7,
+);
+
+//Middle
+vSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+vSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Ring
+vSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+vSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Pinky
+vSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+vSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  0.7,
+);
+
+export default vSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Wsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Wsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const wSign = new GestureDescription("W");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Middle",
+//       "No Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "No Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+wSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+wSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  1.0,
+);
+
+//Index
+wSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+wSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+//Middle
+wSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+wSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Ring
+wSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.NoCurl, 1);
+wSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Pinky
+wSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+wSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpRight,
+  1.0,
+);
+
+export default wSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Xsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Xsign.js
@@ -1,0 +1,65 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const xSign = new GestureDescription("X");
+// [
+//     [
+//       "Thumb",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Index",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Half Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Vertical Up"
+//     ]
+//   ]
+
+//Thumb
+xSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+xSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.8,
+);
+
+//Index
+xSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+xSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  1.0,
+);
+
+//Middle
+xSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+
+//Ring
+xSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+
+//Pinky
+xSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+
+export default xSign;

--- a/src/common/Fingerpose/Gestures/alphabet/Ysign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Ysign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const ySign = new GestureDescription("Y");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Diagonal Up Right"
+//     ],
+//     [
+//       "Index",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Vertical Up"
+//     ],
+//     [
+//       "Pinky",
+//       "No Curl",
+//       "Diagonal Up Left"
+//     ]
+//   ]
+
+//Thumb
+ySign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+ySign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpRight,
+  0.7,
+);
+
+//Index
+ySign.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1);
+ySign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Middle
+ySign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+ySign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Ring
+ySign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+ySign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.VerticalUp,
+  0.7,
+);
+
+//Pinky
+ySign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+ySign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.DiagonalUpLeft,
+  0.7,
+);
+
+export default ySign;

--- a/src/common/Fingerpose/Gestures/alphabet/Zsign.js
+++ b/src/common/Fingerpose/Gestures/alphabet/Zsign.js
@@ -1,0 +1,83 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const zSign = new GestureDescription("Z");
+// [
+//     [
+//       "Thumb",
+//       "No Curl",
+//       "Horizontal Left"
+//     ],
+//     [
+//       "Index",
+//       "No Curl",
+//       "Diagonal Up Left"
+//     ],
+//     [
+//       "Middle",
+//       "Full Curl",
+//       "Horizontal Left"
+//     ],
+//     [
+//       "Ring",
+//       "Full Curl",
+//       "Horizontal Left"
+//     ],
+//     [
+//       "Pinky",
+//       "Full Curl",
+//       "Horizontal Left"
+//     ]
+//   ]
+
+//Thumb
+zSign.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.8);
+zSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.HorizontalLeft,
+  0.7,
+);
+
+//Index
+zSign.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1);
+zSign.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection.DiagonalUpLeft,
+  0.7,
+);
+
+//Middle
+zSign.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+zSign.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection.HorizontalLeft,
+  0.7,
+);
+
+//Ring
+zSign.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+zSign.addDirection(
+  Handedness.Left,
+  Finger.Ring,
+  FingerDirection.HorizontalLeft,
+  0.7,
+);
+
+//Pinky
+zSign.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
+zSign.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection.HorizontalLeft,
+  0.7,
+);
+
+export default zSign;

--- a/src/common/Fingerpose/Gestures/alphabet/index.js
+++ b/src/common/Fingerpose/Gestures/alphabet/index.js
@@ -1,0 +1,57 @@
+import aSign from "./Asign";
+import bSign from "./Bsign";
+import cSign from "./Csign";
+import dSign from "./Dsign";
+import eSign from "./Esign";
+import fSign from "./Fsign";
+import gSign from "./Gsign";
+import hSign from "./Hsign";
+import iSign from "./Isign";
+import jSign from "./Jsign";
+import kSign from "./Ksign";
+import lSign from "./Lsign";
+import mSign from "./Msign";
+import nSign from "./Nsign";
+import oSign from "./Osign";
+import pSign from "./Psign";
+import qSign from "./Qsign";
+import rSign from "./Rsign";
+import sSign from "./Ssign";
+import tSign from "./Tsign";
+import uSign from "./Usign";
+import vSign from "./Vsign";
+import wSign from "./Wsign";
+import xSign from "./Xsign";
+import ySign from "./Ysign";
+import zSign from "./Zsign";
+
+const alphabet = [
+  aSign,
+  bSign,
+  cSign,
+  dSign,
+  eSign,
+  fSign,
+  gSign,
+  hSign,
+  iSign,
+  jSign,
+  kSign,
+  lSign,
+  mSign,
+  nSign,
+  oSign,
+  pSign,
+  qSign,
+  rSign,
+  sSign,
+  tSign,
+  uSign,
+  vSign,
+  wSign,
+  xSign,
+  ySign,
+  zSign,
+];
+
+export default alphabet;

--- a/src/common/Fingerpose/Gestures/index.js
+++ b/src/common/Fingerpose/Gestures/index.js
@@ -1,11 +1,13 @@
 import hello from "./Hello";
 import consonants from "./consonants";
 import vowels from "./vowels";
+import alphabet from "./alphabet";
 
 const Gestures = {
   hello,
   consonants,
   vowels,
+  alphabet,
 };
 
 export default Gestures;


### PR DESCRIPTION
## 주제
- 알파벳 제스처 등록

### 주요 작업사항
**알파벳 제스처 등록**
알파벳 26개 제스처를 등록하였습니다.

다만, p의 경우 한글 모음 "ㅓ"와 마찬가지로 앞으로 찌르는 듯한 제스처를 인지하지 못해 다른 제스처와 구분이 어려습니다.
추가로 u/r/v의 경우 서로 검지와 중지를 위로 찌르는 형태로 살짝 각도만 달라 현재로는 정확하게 인지가 어렵습니다.
마지막으로 z는 동적인 움직임으로 감지가 어렵습니다.

### 주요 작업사항
알파벳 점수 환산에 대하여 contrib 조정이 필요할 것 같습니다. (추후 작업 예정)
