### PR TITLE
[2022/07/10] 손바닥 및 손등 측정 로직 변경 및 한글 모음 제스처 수정

### DIFF
--- a/src/assets/image/vowels/index.js
+++ b/src/assets/image/vowels/index.js
@@ -8,7 +8,7 @@ import u from "./vowels_u.PNG";
 import yu from "./vowels_yu.PNG";
 import eu from "./vowels_eu.PNG";
 import i from "./vowels_i.PNG";
-import ae from "./vowels_yae.PNG";
+import ae from "./vowels_ae.PNG";
 import yae from "./vowels_yae.PNG";
 import e from "./vowels_e.PNG";
 import ye from "./vowels_ye.PNG";

--- a/src/common/Fingerpose/FingerDescription.js
+++ b/src/common/Fingerpose/FingerDescription.js
@@ -3,6 +3,11 @@ const Handedness = {
   Right: "Right",
 };
 
+const HandSide = {
+  Palm: "palm",
+  Back: "back",
+};
+
 const Finger = {
   Thumb: 0,
   Index: 1,
@@ -147,11 +152,6 @@ const FingerDirection = {
   },
 };
 
-const FingerPosition = {
-  Palm: "palm",
-  Back: "back",
-};
-
 const FingerAxis = {
   XY: "xy",
   YZ: "yz",
@@ -159,9 +159,9 @@ const FingerAxis = {
 
 export {
   Handedness,
+  HandSide,
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
   FingerAxis,
 };

--- a/src/common/Fingerpose/FingerPoseEstimator.js
+++ b/src/common/Fingerpose/FingerPoseEstimator.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-unused-expressions */
 
 import {
+  Handedness,
   Finger,
   FingerCurl,
   FingerDirection,
   FingerAxis,
+  HandSide,
 } from "./FingerDescription";
 
 export default class FingerPoseEstimator {
@@ -31,13 +33,7 @@ export default class FingerPoseEstimator {
     let slopesXY = [];
     let slopesZY = [];
 
-    let isPalmOrBack = "";
-
-    if (handedness === "Left") {
-      isPalmOrBack = keypoints3D[2].x > 0 ? "palm" : "back";
-    } else {
-      isPalmOrBack = keypoints3D[2].x < 0 ? "palm" : "back";
-    }
+    let isPalmOrBack = this.estimateHandSide(handedness, keypoints3D);
 
     for (let finger of Finger.all) {
       let points = Finger.getPoints(finger);
@@ -113,6 +109,110 @@ export default class FingerPoseEstimator {
     }
 
     return { curls: fingerCurls, directions: fingerDirections };
+  }
+
+  estimateHandSide(handedness, keypoints) {
+    const wrist = keypoints[0];
+    const thumb_mcp = keypoints[2];
+    const pinky_tip = keypoints[20];
+
+    const { x: wirst_x, y: wirst_y } = wrist;
+    const { x: thumb_mcp_x, y: thumb_mcp_y } = thumb_mcp;
+    const { x: pinky_tip_x, y: pinky_tip_y } = pinky_tip;
+
+    let expectedHandSide;
+
+    if (
+      wirst_x < thumb_mcp_x &&
+      thumb_mcp_x > pinky_tip_x &&
+      wirst_y > thumb_mcp_y &&
+      thumb_mcp_y > pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Palm;
+      } else {
+        expectedHandSide = HandSide.Back;
+      }
+    } else if (
+      wirst_x < thumb_mcp_x &&
+      thumb_mcp_x < pinky_tip_x &&
+      wirst_y < thumb_mcp_y &&
+      thumb_mcp_y > pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Palm;
+      } else {
+        expectedHandSide = HandSide.Back;
+      }
+    } else if (
+      wirst_x > thumb_mcp_x &&
+      thumb_mcp_x > pinky_tip_x &&
+      wirst_y > thumb_mcp_y &&
+      thumb_mcp_y < pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Palm;
+      } else {
+        expectedHandSide = HandSide.Back;
+      }
+    } else if (
+      wirst_x > thumb_mcp_x &&
+      thumb_mcp_x < pinky_tip_x &&
+      wirst_y < thumb_mcp_y &&
+      thumb_mcp_y < pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Palm;
+      } else {
+        expectedHandSide = HandSide.Back;
+      }
+    } else if (
+      wirst_x > thumb_mcp_x &&
+      thumb_mcp_x < pinky_tip_x &&
+      wirst_y > thumb_mcp_y &&
+      thumb_mcp_y > pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Back;
+      } else {
+        expectedHandSide = HandSide.Palm;
+      }
+    } else if (
+      wirst_x < thumb_mcp_x &&
+      thumb_mcp_x < pinky_tip_x &&
+      wirst_y > thumb_mcp_y &&
+      thumb_mcp_y < pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Back;
+      } else {
+        expectedHandSide = HandSide.Palm;
+      }
+    } else if (
+      wirst_x > thumb_mcp_x &&
+      thumb_mcp_x > pinky_tip_x &&
+      wirst_y < thumb_mcp_y &&
+      thumb_mcp_y > pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Back;
+      } else {
+        expectedHandSide = HandSide.Palm;
+      }
+    } else if (
+      wirst_x < thumb_mcp_x &&
+      thumb_mcp_x > pinky_tip_x &&
+      wirst_y < thumb_mcp_y &&
+      thumb_mcp_y < pinky_tip_y
+    ) {
+      if (handedness === Handedness.Left) {
+        expectedHandSide = HandSide.Back;
+      } else {
+        expectedHandSide = HandSide.Palm;
+      }
+    }
+
+    return expectedHandSide;
   }
 
   // point1, point2 are 2d or 3d point arrays (xy[z])

--- a/src/common/Fingerpose/Gestures/consonants/Bieup.js
+++ b/src/common/Fingerpose/Gestures/consonants/Bieup.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Chieut.js
+++ b/src/common/Fingerpose/Gestures/consonants/Chieut.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Digeut.js
+++ b/src/common/Fingerpose/Gestures/consonants/Digeut.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Giyeok.js
+++ b/src/common/Fingerpose/Gestures/consonants/Giyeok.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -29,9 +29,9 @@ giyeok.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Back,
+  HandSide.Back,
 );
-giyeok.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.7);
+giyeok.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
 giyeok.addDirection(
   Handedness.Left,
   Finger.Index,
@@ -40,7 +40,7 @@ giyeok.addDirection(
 );
 
 giyeok.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
-giyeok.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1.0);
+giyeok.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
 giyeok.addDirection(
   Handedness.Left,
   Finger.Middle,
@@ -50,20 +50,8 @@ giyeok.addDirection(
 
 giyeok.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
 giyeok.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.8);
-giyeok.addDirection(
-  Handedness.Left,
-  Finger.Ring,
-  FingerDirection[FingerAxis.XY].VerticalDown,
-  0.8,
-);
 
 giyeok.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1);
 giyeok.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
-giyeok.addDirection(
-  Handedness.Left,
-  Finger.Pinky,
-  FingerDirection[FingerAxis.XY].VerticalDown,
-  0.8,
-);
 
 export default giyeok;

--- a/src/common/Fingerpose/Gestures/consonants/Hieut.js
+++ b/src/common/Fingerpose/Gestures/consonants/Hieut.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Ieung.js
+++ b/src/common/Fingerpose/Gestures/consonants/Ieung.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Jieut.js
+++ b/src/common/Fingerpose/Gestures/consonants/Jieut.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -15,7 +15,7 @@ jieut.addDirection(
   Handedness.Left,
   Finger.Thumb,
   FingerDirection[FingerAxis.XY].HorizontalRight,
-  1.0,
+  0.8,
 );
 jieut.addDirection(
   Handedness.Left,
@@ -24,7 +24,13 @@ jieut.addDirection(
   0.8,
 );
 
-jieut.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+jieut.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Back,
+);
 jieut.addDirection(
   Handedness.Left,
   Finger.Index,

--- a/src/common/Fingerpose/Gestures/consonants/Kieuk.js
+++ b/src/common/Fingerpose/Gestures/consonants/Kieuk.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Mieum.js
+++ b/src/common/Fingerpose/Gestures/consonants/Mieum.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Nieun.js
+++ b/src/common/Fingerpose/Gestures/consonants/Nieun.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -29,7 +29,7 @@ niuen.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 niuen.addDirection(
   Handedness.Left,

--- a/src/common/Fingerpose/Gestures/consonants/Pieup.js
+++ b/src/common/Fingerpose/Gestures/consonants/Pieup.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Riuel.js
+++ b/src/common/Fingerpose/Gestures/consonants/Riuel.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/consonants/Siot.js
+++ b/src/common/Fingerpose/Gestures/consonants/Siot.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -23,7 +23,7 @@ siot.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 siot.addDirection(
   Handedness.Left,

--- a/src/common/Fingerpose/Gestures/consonants/Tieut.js
+++ b/src/common/Fingerpose/Gestures/consonants/Tieut.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";

--- a/src/common/Fingerpose/Gestures/vowels/A.js
+++ b/src/common/Fingerpose/Gestures/vowels/A.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -25,13 +25,7 @@ a.addDirection(
   0.8,
 );
 
-a.addCurl(
-  Handedness.Left,
-  Finger.Index,
-  FingerCurl.NoCurl,
-  1.0,
-  FingerPosition.Palm,
-);
+a.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0, HandSide.Palm);
 a.addDirection(
   Handedness.Left,
   Finger.Index,

--- a/src/common/Fingerpose/Gestures/vowels/Ae.js
+++ b/src/common/Fingerpose/Gestures/vowels/Ae.js
@@ -3,41 +3,52 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
 const ae = new GestureDescription("ae");
 
 ae.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+ae.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
 
 ae.addCurl(
   Handedness.Left,
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
-ae.addDirection(Handedness.Left, Finger.Index, FingerDirection.VerticalUp, 1.0);
+ae.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
 
 ae.addCurl(
   Handedness.Left,
   Finger.Middle,
   FingerCurl.FullCurl,
   1.0,
-  FingerPosition.Palm,
-);
-ae.addCurl(
-  Handedness.Left,
-  Finger.Middle,
-  FingerCurl.HalfCurl,
-  0.9,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
 
 ae.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
 
-ae.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1.0);
-ae.addDirection(Handedness.Left, Finger.Pinky, FingerDirection.VerticalUp, 1.0);
+ae.addCurl(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Palm,
+);
+ae.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
 
 export default ae;

--- a/src/common/Fingerpose/Gestures/vowels/E.js
+++ b/src/common/Fingerpose/Gestures/vowels/E.js
@@ -1,0 +1,55 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const e = new GestureDescription("e");
+
+e.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+e.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.8);
+
+e.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0, HandSide.Palm);
+e.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  0.8,
+  HandSide.Palm,
+);
+e.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
+);
+e.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].ForwardUp,
+  0.8,
+  FingerAxis.YZ,
+);
+
+e.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
+e.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1.0);
+
+e.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
+e.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1.0);
+
+e.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+e.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 1.0);
+e.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
+);
+
+export default e;

--- a/src/common/Fingerpose/Gestures/vowels/Eo.js
+++ b/src/common/Fingerpose/Gestures/vowels/Eo.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -13,20 +13,8 @@ const eo = new GestureDescription("eo");
 eo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
 eo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.8);
 
-eo.addCurl(
-  Handedness.Left,
-  Finger.Index,
-  FingerCurl.NoCurl,
-  1.0,
-  FingerPosition.Palm,
-);
-eo.addCurl(
-  Handedness.Left,
-  Finger.Index,
-  FingerCurl.HalfCurl,
-  0.8,
-  FingerPosition.Palm,
-);
+eo.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+eo.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
 eo.addDirection(
   Handedness.Left,
   Finger.Index,

--- a/src/common/Fingerpose/Gestures/vowels/Eu.js
+++ b/src/common/Fingerpose/Gestures/vowels/Eu.js
@@ -3,6 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -13,8 +14,8 @@ eu.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.9);
 eu.addDirection(
   Handedness.Left,
   Finger.Thumb,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 eu.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
@@ -22,8 +23,8 @@ eu.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.9);
 eu.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 eu.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/I.js
+++ b/src/common/Fingerpose/Gestures/vowels/I.js
@@ -3,7 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -19,18 +20,17 @@ i.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
 
 i.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
 
-i.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1.0);
+i.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1.0, HandSide.Palm);
 i.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.VerticalUp,
-  1.0,
-  FingerPosition.Palm,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 i.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.DiagonalUpLeft,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
   0.9,
 );
 

--- a/src/common/Fingerpose/Gestures/vowels/O.js
+++ b/src/common/Fingerpose/Gestures/vowels/O.js
@@ -3,7 +3,7 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
   FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
@@ -19,13 +19,7 @@ o.addDirection(
   0.8,
 );
 
-o.addCurl(
-  Handedness.Left,
-  Finger.Index,
-  FingerCurl.NoCurl,
-  1.0,
-  FingerPosition.Back,
-);
+o.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0, HandSide.Back);
 o.addDirection(
   Handedness.Left,
   Finger.Index,
@@ -45,14 +39,14 @@ o.addCurl(
   Finger.Middle,
   FingerCurl.FullCurl,
   1,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 o.addCurl(
   Handedness.Left,
   Finger.Middle,
   FingerCurl.HalfCurl,
   0.8,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 
 o.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/Oe.js
+++ b/src/common/Fingerpose/Gestures/vowels/Oe.js
@@ -3,7 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -29,14 +30,13 @@ oe.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Back,
+  HandSide.Back,
 );
-oe.addDirection(Handedness.Left, Finger.Index, FingerDirection.VerticalUp, 1.0);
 oe.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.DiagonalUpRight,
-  0.8,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  1.0,
 );
 
 oe.addCurl(
@@ -44,25 +44,25 @@ oe.addCurl(
   Finger.Middle,
   FingerCurl.FullCurl,
   1,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 oe.addCurl(
   Handedness.Left,
   Finger.Middle,
   FingerCurl.HalfCurl,
   0.8,
-  FingerPosition.Back,
+  HandSide.Back,
 );
 
 oe.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
 oe.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
 
-oe.addCurl(
+oe.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1, HandSide.Back);
+oe.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerCurl.NoCurl,
-  1,
-  FingerPosition.Back,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  1.0,
 );
 
 export default oe;

--- a/src/common/Fingerpose/Gestures/vowels/U.js
+++ b/src/common/Fingerpose/Gestures/vowels/U.js
@@ -3,20 +3,41 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
 const u = new GestureDescription("u");
 
 u.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+u.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
 
-u.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
-u.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+u.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0, HandSide.Back);
+u.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Back,
+);
 u.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.VerticalDown,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
+u.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].VerticalDown,
+  0.8,
+  FingerAxis.YZ,
 );
 
 u.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/Ui.js
+++ b/src/common/Fingerpose/Gestures/vowels/Ui.js
@@ -3,6 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -10,33 +12,40 @@ const ui = new GestureDescription("ui");
 
 ui.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
 ui.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.9);
-ui.addDirection(
-  Handedness.Left,
-  Finger.Thumb,
-  FingerDirection.HorizontalRight,
-  1.0,
-);
 
-ui.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
-ui.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.9);
+ui.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Back,
+);
+ui.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  0.9,
+  HandSide.Back,
+);
 ui.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 ui.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
 ui.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 0.8);
 
 ui.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+ui.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1);
 
 ui.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
 ui.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 export default ui;

--- a/src/common/Fingerpose/Gestures/vowels/Wi.js
+++ b/src/common/Fingerpose/Gestures/vowels/Wi.js
@@ -3,6 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -10,25 +12,56 @@ const wi = new GestureDescription("wi");
 
 wi.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
 
-wi.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
-wi.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+wi.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Back,
+);
+wi.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Back,
+);
 wi.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.VerticalDown,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
+wi.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].DiagonalDownRight,
+  0.8,
 );
 
-wi.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1);
+wi.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
 
-wi.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);
+wi.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
 
-wi.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1);
+wi.addCurl(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Back,
+);
+wi.addCurl(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Back,
+);
 wi.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.VerticalDown,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
 );
 
 export default wi;

--- a/src/common/Fingerpose/Gestures/vowels/Ya.js
+++ b/src/common/Fingerpose/Gestures/vowels/Ya.js
@@ -3,7 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -16,22 +17,27 @@ ya.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
-ya.addDirection(Handedness.Left, Finger.Index, FingerDirection.VerticalUp, 1.0);
+ya.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
 
 ya.addCurl(
   Handedness.Left,
   Finger.Middle,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
 ya.addDirection(
   Handedness.Left,
   Finger.Middle,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 
 ya.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);

--- a/src/common/Fingerpose/Gestures/vowels/Yae.js
+++ b/src/common/Fingerpose/Gestures/vowels/Yae.js
@@ -3,26 +3,28 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
 const yae = new GestureDescription("yae");
 
 yae.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+yae.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
 
 yae.addCurl(
   Handedness.Left,
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
 yae.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 
 yae.addCurl(
@@ -30,19 +32,13 @@ yae.addCurl(
   Finger.Middle,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Palm,
+  HandSide.Palm,
 );
 yae.addDirection(
   Handedness.Left,
   Finger.Middle,
   FingerDirection.VerticalUp,
-  1.0,
-);
-yae.addDirection(
-  Handedness.Left,
-  Finger.Middle,
-  FingerDirection.DiagonalUpRight,
-  0.9,
+  0.8,
 );
 
 yae.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
@@ -51,8 +47,8 @@ yae.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1.0);
 yae.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 
 export default yae;

--- a/src/common/Fingerpose/Gestures/vowels/Ye.js
+++ b/src/common/Fingerpose/Gestures/vowels/Ye.js
@@ -1,0 +1,68 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const ye = new GestureDescription("ye");
+
+ye.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
+ye.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.8);
+
+ye.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Palm,
+);
+ye.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  0.8,
+  HandSide.Palm,
+);
+ye.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
+);
+ye.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].ForwardUp,
+  0.8,
+  FingerAxis.YZ,
+);
+
+ye.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1.0);
+ye.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1.0);
+ye.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
+);
+
+ye.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
+ye.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 1.0);
+
+ye.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+ye.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 1.0);
+ye.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
+);
+
+export default ye;

--- a/src/common/Fingerpose/Gestures/vowels/Yeo.js
+++ b/src/common/Fingerpose/Gestures/vowels/Yeo.js
@@ -3,7 +3,8 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
@@ -17,16 +18,25 @@ yeo.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
 yeo.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
 );
 
-yeo.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 1);
+yeo.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
+yeo.addCurl(
+  Handedness.Left,
+  Finger.Middle,
+  FingerCurl.HalfCurl,
+  0.8,
+  HandSide.Palm,
+);
 yeo.addDirection(
   Handedness.Left,
-  Finger.Index,
-  FingerDirection.HorizontalRight,
-  1.0,
+  Finger.Middle,
+  FingerDirection[FingerAxis.YZ].ForwardMiddle,
+  0.8,
+  FingerAxis.YZ,
 );
 
 yeo.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/Yo.js
+++ b/src/common/Fingerpose/Gestures/vowels/Yo.js
@@ -3,25 +3,20 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-  FingerPosition,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
 const yo = new GestureDescription("yo");
 
-yo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 1.0);
-yo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 0.8);
+yo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+yo.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.HalfCurl, 0.8);
 yo.addDirection(
   Handedness.Left,
   Finger.Thumb,
-  FingerDirection.DiagonalUpRight,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
   1.0,
-);
-yo.addDirection(
-  Handedness.Left,
-  Finger.Thumb,
-  FingerDirection.HorizontalRight,
-  0.8,
 );
 
 yo.addCurl(
@@ -29,28 +24,21 @@ yo.addCurl(
   Finger.Index,
   FingerCurl.NoCurl,
   1.0,
-  FingerPosition.Back,
+  HandSide.Back,
 );
-yo.addDirection(Handedness.Left, Finger.Index, FingerDirection.VerticalUp, 1.0);
 yo.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.DiagonalUpRight,
+  FingerDirection[FingerAxis.XY].VerticalUp,
   0.8,
 );
 
-yo.addCurl(
-  Handedness.Left,
-  Finger.Middle,
-  FingerCurl.NoCurl,
-  1,
-  FingerPosition.Back,
-);
+yo.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1, HandSide.Back);
 yo.addDirection(
   Handedness.Left,
   Finger.Middle,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 
 yo.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/Yu.js
+++ b/src/common/Fingerpose/Gestures/vowels/Yu.js
@@ -3,28 +3,62 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
+  HandSide,
+  FingerAxis,
 } from "../../FingerDescription";
 import GestureDescription from "../../GestureDescription";
 
 const yu = new GestureDescription("yu");
 
 yu.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+yu.addDirection(
+  Handedness.Left,
+  Finger.Thumb,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
 
-yu.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
-yu.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 1.0);
+yu.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Back,
+);
+yu.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Back,
+);
 yu.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.VerticalDown,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
+yu.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.YZ].VerticalDown,
+  0.8,
+  FingerAxis.YZ,
 );
 
 yu.addCurl(Handedness.Left, Finger.Middle, FingerCurl.NoCurl, 1);
 yu.addDirection(
   Handedness.Left,
   Finger.Middle,
-  FingerDirection.VerticalDown,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalDown,
+  0.8,
+);
+yu.addDirection(
+  Handedness.Left,
+  Finger.Middle,
+  FingerDirection[FingerAxis.YZ].VerticalDown,
+  0.8,
+  FingerAxis.YZ,
 );
 
 yu.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1);

--- a/src/common/Fingerpose/Gestures/vowels/index.js
+++ b/src/common/Fingerpose/Gestures/vowels/index.js
@@ -10,11 +10,30 @@ import eu from "./Eu";
 import i from "./I";
 import ae from "./Ae";
 import yae from "./Yae";
+import e from "./E";
+import ye from "./Ye";
 import oe from "./Oe";
 import wi from "./Wi";
 import ui from "./Ui";
 
-const vowels = [a, eo, o];
-// const vowels = [a, ya, eo, yeo, o, yo, u, yu, eu, i, ae, yae, oe, wi, ui];
+const vowels = [
+  a,
+  ya,
+  eo,
+  yeo,
+  o,
+  yo,
+  u,
+  yu,
+  eu,
+  i,
+  ae,
+  yae,
+  e,
+  ye,
+  oe,
+  wi,
+  ui,
+];
 
 export default vowels;


### PR DESCRIPTION
## 주제
- 손바닥 및 손등 측정 로직 변경
- 한글 모음 제스처 수정



### 주요 작업사항
**손바닥 및 손등 측정 로직 변경**
기존 thumb_mcp 좌표 기준으로 wrist보다 양수인지 음수인지에 따라서만 손바닥 손등을 구분하다보니,
손등을 앞으로 해서 손가락을 밑으로 펼칠 때 손바닥으로 인식하였습니다.

우선 주먹을 쥐거나 일반적인 손바닥/손등을 구분할 수 없는 제스처 등을 제외하고는 아래와 같이 적용할 수 있었습니다.

기준) wrist,  thumb_mcp 및 pinky_tip의 x, y 좌표
조건) thumb_mcp보다 나머지 기준의 x,y좌표가 크거나 작은지 여부를 판단 

`    let isPalmOrBack = this.estimateHandSide(handedness, keypoints3D);
`

![image](https://user-images.githubusercontent.com/94096095/178152857-39e0dd3d-90f6-48ba-9733-ab336bf6517d.png)


손바닥, 손등에 따라 추가점을 주고 싶은 제스처에 추가하면 높은 점수를 반환할 수 있습니다. 



**한글 모음 제스처 수정**
제스처 등록 형식이 수정되면서 기존에 작성했던 한글 자음 제스처를 수정하였습니다.
다만, "ㅓ" 등의 앞으로 찌르는 제스처의 경우 핸드포즈 모델 자체가 좌표를 제대로 읽지 못하는 경우가 많아
제대로 제스처를 반환하지 못하고 있습니다. 


