### PR TITLE
[2022/07/12] 화면 제스처를 탐지하여 텍스트 및 음성 출력, 양손 제스처 등록 및 비디오 facing mode 옵션 삭제

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import TestResult from "./pages/Practice/TestResult";
 import Communication from "./pages/Communication";
 import CommunicationMain from "./pages/Communication/CommunicationMain";
 import SelfGesture from "./pages/Communication/SelfGesture";
+import HandGesture from "./pages/Communication/HandGesture";
 
 function App() {
   return (
@@ -28,6 +29,7 @@ function App() {
         <Route path="/communication" element={<Communication />}>
           <Route index element={<CommunicationMain />} />
           <Route path="selfgesture" element={<SelfGesture />} />
+          <Route path="handgesture" element={<HandGesture />} />
         </Route>
       </Routes>
     </Wrapper>

--- a/src/common/Fingerpose/Gestures/index.js
+++ b/src/common/Fingerpose/Gestures/index.js
@@ -1,10 +1,10 @@
-import hello from "./Hello";
+import words from "./words";
 import consonants from "./consonants";
 import vowels from "./vowels";
 import alphabet from "./alphabet";
 
 const Gestures = {
-  hello,
+  words,
   consonants,
   vowels,
   alphabet,

--- a/src/common/Fingerpose/Gestures/words/Erase.js
+++ b/src/common/Fingerpose/Gestures/words/Erase.js
@@ -1,0 +1,50 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const erase = new GestureDescription("erase");
+
+erase.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+erase.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.HalfCurl, 0.8);
+erase.addDirection(
+  Handedness.Right,
+  Finger.Thumb,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
+);
+
+erase.addCurl(
+  Handedness.Right,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Palm,
+);
+erase.addDirection(
+  Handedness.Right,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+erase.addCurl(Handedness.Right, Finger.Middle, FingerCurl.NoCurl, 1.0);
+erase.addDirection(
+  Handedness.Right,
+  Finger.Middle,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+erase.addCurl(Handedness.Right, Finger.Ring, FingerCurl.FullCurl, 1.0);
+erase.addCurl(Handedness.Right, Finger.Ring, FingerCurl.HalfCurl, 0.8);
+
+erase.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+erase.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.HalfCurl, 0.8);
+
+export default erase;

--- a/src/common/Fingerpose/Gestures/words/Hello.js
+++ b/src/common/Fingerpose/Gestures/words/Hello.js
@@ -3,8 +3,10 @@ import {
   Finger,
   FingerCurl,
   FingerDirection,
-} from "../FingerDescription";
-import GestureDescription from "../GestureDescription";
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
 
 // describe victory gesture ✌️
 const hello = new GestureDescription("hello");
@@ -13,14 +15,14 @@ const hello = new GestureDescription("hello");
 hello.addDirection(
   Handedness.Left,
   Finger.Thumb,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Left,
   Finger.Thumb,
-  FingerDirection.DiagonalUpRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
 );
 
 // index:
@@ -29,14 +31,14 @@ hello.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Left,
   Finger.Index,
-  FingerDirection.DiagonalUpRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
 );
 
 // middle:
@@ -45,14 +47,14 @@ hello.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Left,
   Finger.Middle,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Left,
   Finger.Middle,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 // ring:
@@ -61,14 +63,14 @@ hello.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Left,
   Finger.Ring,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Left,
   Finger.Ring,
-  FingerDirection.DiagonalUpRight,
-  0.9,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
 );
 
 // pinky:
@@ -77,14 +79,14 @@ hello.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Left,
   Finger.Pinky,
-  FingerDirection.DiagonalUpLeft,
-  0.9,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
+  0.8,
 );
 
 // thumb:
@@ -92,13 +94,13 @@ hello.addDirection(
   Handedness.Right,
   Finger.Thumb,
   FingerDirection.VerticalUp,
-  1.0,
+  0.8,
 );
 hello.addDirection(
   Handedness.Right,
   Finger.Thumb,
-  FingerDirection.DiagonalUpLeft,
-  1.0,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
+  0.8,
 );
 
 // index:
@@ -107,14 +109,14 @@ hello.addCurl(Handedness.Right, Finger.Index, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Right,
   Finger.Index,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Right,
   Finger.Index,
-  FingerDirection.DiagonalUpLeft,
-  1.0,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
+  0.8,
 );
 
 // middle:
@@ -123,14 +125,14 @@ hello.addCurl(Handedness.Right, Finger.Middle, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Right,
   Finger.Middle,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Right,
   Finger.Middle,
-  FingerDirection.HorizontalRight,
-  1.0,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
 );
 
 // ring:
@@ -139,14 +141,14 @@ hello.addCurl(Handedness.Right, Finger.Ring, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Right,
   Finger.Ring,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Right,
   Finger.Ring,
-  FingerDirection.DiagonalUpRight,
-  0.9,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
 );
 
 // pinky:
@@ -155,14 +157,14 @@ hello.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Right,
   Finger.Pinky,
-  FingerDirection.VerticalUp,
-  1.0,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
 );
 hello.addDirection(
   Handedness.Right,
   Finger.Pinky,
-  FingerDirection.DiagonalUpRight,
-  0.9,
+  FingerDirection[FingerAxis.XY].DiagonalUpRight,
+  0.8,
 );
 
 export default hello;

--- a/src/common/Fingerpose/Gestures/words/Meet.js
+++ b/src/common/Fingerpose/Gestures/words/Meet.js
@@ -1,0 +1,55 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const meet = new GestureDescription("meet");
+
+// thumb:
+meet.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+// index:
+meet.addCurl(Handedness.Left, Finger.Index, FingerCurl.NoCurl, 1.0);
+meet.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+// middle:
+meet.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
+
+// ring:
+meet.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
+
+// pinky:
+meet.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+
+// thumb:
+meet.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+// index:
+meet.addCurl(Handedness.Right, Finger.Index, FingerCurl.NoCurl, 1.0);
+meet.addDirection(
+  Handedness.Right,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+// middle:
+meet.addCurl(Handedness.Right, Finger.Middle, FingerCurl.FullCurl, 1.0);
+
+// ring:
+meet.addCurl(Handedness.Right, Finger.Ring, FingerCurl.FullCurl, 1.0);
+
+// pinky:
+meet.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.FullCurl, 1.0);
+
+export default meet;

--- a/src/common/Fingerpose/Gestures/words/Speech.js
+++ b/src/common/Fingerpose/Gestures/words/Speech.js
@@ -1,0 +1,48 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const speech = new GestureDescription("speech");
+
+speech.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+speech.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.HalfCurl, 0.8);
+speech.addDirection(
+  Handedness.Right,
+  Finger.Thumb,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
+  0.8,
+);
+
+speech.addCurl(
+  Handedness.Right,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Palm,
+);
+speech.addDirection(
+  Handedness.Right,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].DiagonalUpLeft,
+  0.8,
+);
+
+speech.addCurl(Handedness.Right, Finger.Middle, FingerCurl.NoCurl, 1.0);
+speech.addDirection(
+  Handedness.Right,
+  Finger.Middle,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+speech.addCurl(Handedness.Right, Finger.Ring, FingerCurl.NoCurl, 1.0);
+
+speech.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.NoCurl, 1.0);
+
+export default speech;

--- a/src/common/Fingerpose/Gestures/words/index.js
+++ b/src/common/Fingerpose/Gestures/words/index.js
@@ -1,0 +1,8 @@
+import hello from "./Hello";
+import erase from "./Erase";
+import speech from "./Speech";
+import meet from "./Meet";
+
+const words = [hello, erase, speech, meet];
+
+export default words;

--- a/src/components/atoms/Video.js
+++ b/src/components/atoms/Video.js
@@ -5,13 +5,10 @@ import PropTypes from "prop-types";
 
 import { FACING_MODE } from "../../constants/webcam";
 
-function Video({ facingMode }, ref) {
+function Video(props, ref) {
   const videoConfig = {
     width: 360,
-    facingMode:
-      facingMode === FACING_MODE.user
-        ? FACING_MODE.user
-        : { exact: FACING_MODE.environment },
+    facingMode: FACING_MODE.user,
   };
 
   return (
@@ -38,7 +35,6 @@ const StyledVideo = styled(Webcam)`
 `;
 
 Video.propTypes = {
-  facingMode: PropTypes.string,
   ref: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.elementType }),

--- a/src/constants/communication.js
+++ b/src/constants/communication.js
@@ -5,7 +5,7 @@ export const COMMUNICATION_LIST = [
     description:
       "화면에 비치는 손을 실시간으로\n인식하여 텍스트를 출력합니다.\n현재 학습된 수어만 인식 가능합니다.",
     buttonTitle: "인식하기",
-    page: "signlanguage",
+    page: "handgesture",
   },
   {
     id: 1,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,6 @@
 import { COMMUNICATION_LIST } from "./communication";
 import { Letter, lengthOfLetter } from "./letter";
+import WORD from "./word";
 import { PRACTICE_LIST, PRACTICE_TITLE, PRACTICE_DETECTED } from "./practice";
 import { FACING_MODE } from "./webcam";
 
@@ -11,4 +12,5 @@ export {
   PRACTICE_TITLE,
   PRACTICE_DETECTED,
   FACING_MODE,
+  WORD,
 };

--- a/src/constants/word.js
+++ b/src/constants/word.js
@@ -1,0 +1,6 @@
+const WORD = {
+  hello: "안녕하세요",
+  meet: "반갑습니다",
+};
+
+export default WORD;

--- a/src/pages/Communication/HandGesture.js
+++ b/src/pages/Communication/HandGesture.js
@@ -1,0 +1,230 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import { nanoid } from "nanoid";
+import "@tensorflow/tfjs-core";
+import "@tensorflow/tfjs-converter";
+import "@tensorflow/tfjs-backend-webgl";
+
+import { setHandDetector, drawHandKeypoints } from "../../common/utilities";
+import { GestureEstimator, Gestures } from "../../common/Fingerpose";
+
+import HeaderContent from "../../components/organisms/HeaderContent";
+import VideoContent from "../../components/organisms/VideoContent";
+import Text from "../../components/atoms/Text";
+import ButtonList from "../../components/molecules/ButtonList";
+import Button from "../../components/atoms/Button";
+
+import { WORD } from "../../constants";
+
+function HandGesture() {
+  const webcamRef = useRef(null);
+  const canvasRef = useRef(null);
+  const navigate = useNavigate();
+  const [speech, setSpeech] = useState(null);
+  const [score, setScore] = useState(0);
+  const [words, setWords] = useState([]);
+  const [detector, setDetector] = useState(false);
+  const wordsRef = useRef(words);
+  wordsRef.current = words;
+  // const indexOfLetter = indexGestures[typeOfLetter];
+  // const engNameOfCurrentLetter = Letter[typeOfLetter][indexOfLetter];
+  // const koreanNameOfCurrentLetter = Letter[typeOfLetter].getName(
+  //   engNameOfCurrentLetter,
+  // );
+
+  const handleWordsInitialize = () => {
+    setWords([]);
+  };
+
+  const moveToCommunicationMain = () => {
+    navigate("/communication");
+  };
+
+  const handleWordsSpeech = (words) => {
+    if (words.length) {
+      speech.text = words;
+      window.speechSynthesis.speak(speech);
+    }
+  };
+
+  const detectHands = async (detector) => {
+    if (
+      typeof webcamRef.current !== "undefined" &&
+      webcamRef.current !== null &&
+      webcamRef.current.video.readyState === 4
+    ) {
+      const video = webcamRef.current.video;
+      const { videoWidth, videoHeight } = video;
+
+      webcamRef.current.video.width = videoWidth;
+      webcamRef.current.video.height = videoHeight;
+
+      canvasRef.current.width = videoWidth;
+      canvasRef.current.height = videoHeight;
+
+      try {
+        const hand = await detector.estimateHands(video);
+        const GE = new GestureEstimator(Gestures.words);
+
+        if (hand.length > 0) {
+          const gesture = GE.estimate(hand, 7.5);
+          console.log("gesture", gesture);
+
+          const bestGesture = gesture.map((hand) => {
+            const score = hand.gestures.map((prediction) => prediction.score);
+            const maxScore = score.indexOf(Math.max(...score));
+
+            if (!hand.gestures.length) {
+              return;
+            }
+
+            return hand.gestures[maxScore];
+          });
+
+          if (bestGesture.length > 1 && bestGesture[0] && bestGesture[1]) {
+            const [hand1, hand2] = bestGesture;
+            console.log(hand1, hand2);
+
+            if (hand1.name === hand2.name) {
+              const averageScore = (hand1.score + hand2.score) / 2;
+              const scoreToString = (averageScore + "").substring(0, 4);
+
+              // setWords((previous) => {
+              //   return [...previous, hand1.name];
+              // });
+              setWords((previous) => {
+                if (previous.includes(WORD[hand1.name])) {
+                  return [...previous];
+                } else {
+                  return [...previous, WORD[hand1.name]];
+                }
+              });
+              setScore(scoreToString);
+            }
+          } else if (
+            bestGesture.length === 1 &&
+            bestGesture[0] &&
+            bestGesture[0].numberOfHands === 1
+          ) {
+            if (bestGesture[0].name === "erase") {
+              setWords((previous) => {
+                const copy = [...previous];
+                copy.pop();
+
+                return [...copy];
+              });
+            } else if (bestGesture[0].name === "speech") {
+              console.log(wordsRef.current);
+              handleWordsSpeech(wordsRef.current);
+            } else {
+              const scoreToString = (bestGesture[0].score + "").substring(0, 4);
+
+              setScore(scoreToString);
+              setWords((previous) => [...previous, WORD[bestGesture[0].name]]);
+            }
+          }
+        } else {
+          setScore(0);
+        }
+
+        const ctx = canvasRef.current.getContext("2d");
+        drawHandKeypoints(hand, ctx);
+      } catch (error) {
+        console.log("error", error);
+        detector.dispose();
+      }
+    }
+  };
+
+  useEffect(() => {
+    const runHandpose = async () => {
+      const detector = await setHandDetector();
+      const speech = new SpeechSynthesisUtterance();
+      const voices = window.speechSynthesis.getVoices();
+      speech.voice = voices.find((voice) => voice.name === "Google 한국의");
+
+      console.log("detector ready");
+      setDetector(detector);
+      setSpeech(speech);
+    };
+
+    runHandpose();
+  }, []);
+
+  useEffect(() => {
+    let timerId;
+
+    if (detector) {
+      timerId = setInterval(() => {
+        detectHands(detector);
+      }, 1000);
+      console.log(timerId);
+    }
+
+    return () => clearInterval(timerId);
+  }, [detector]);
+
+  return (
+    <Container>
+      <HeaderContent title="연습하기" onClick={moveToCommunicationMain} />
+      <VideoContent webcamRef={webcamRef} canvasRef={canvasRef} />
+      <ContentWrapper>
+        <TextBox>
+          {words.map((word) => (
+            <Text key={nanoid()} className="big">
+              {word}
+            </Text>
+          ))}
+        </TextBox>
+        <TextWrapper>
+          <Text className="normal">{`정확도 : ${score}`}</Text>
+        </TextWrapper>
+        <ButtonList>
+          <Button className="normal" onClick={handleWordsInitialize}>
+            초기화
+          </Button>
+          <Button className="normal" onClick={() => handleWordsSpeech(words)}>
+            텍스트 읽기
+          </Button>
+        </ButtonList>
+      </ContentWrapper>
+    </Container>
+  );
+}
+
+export default HandGesture;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: auto 0;
+  width: 90vw;
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  width: 86vw;
+  height: 15vh;
+  margin: 1rem 0;
+  border: 1px solid black;
+`;
+
+const TextWrapper = styled.div`
+  width: 86vw;
+  height: 8vh;
+  line-height: 8vh;
+  text-align: center;
+  border: 1px solid black;
+  margin: 0.5rem 0;
+`;

--- a/src/pages/Communication/HandGesture.js
+++ b/src/pages/Communication/HandGesture.js
@@ -28,11 +28,6 @@ function HandGesture() {
   const [detector, setDetector] = useState(false);
   const wordsRef = useRef(words);
   wordsRef.current = words;
-  // const indexOfLetter = indexGestures[typeOfLetter];
-  // const engNameOfCurrentLetter = Letter[typeOfLetter][indexOfLetter];
-  // const koreanNameOfCurrentLetter = Letter[typeOfLetter].getName(
-  //   engNameOfCurrentLetter,
-  // );
 
   const handleWordsInitialize = () => {
     setWords([]);
@@ -91,9 +86,6 @@ function HandGesture() {
               const averageScore = (hand1.score + hand2.score) / 2;
               const scoreToString = (averageScore + "").substring(0, 4);
 
-              // setWords((previous) => {
-              //   return [...previous, hand1.name];
-              // });
               setWords((previous) => {
                 if (previous.includes(WORD[hand1.name])) {
                   return [...previous];


### PR DESCRIPTION
## 주제
- 화면 제스처를 탐지하여 텍스트 및 음성 출력
- 양손 제스처 등록
- 비디오 facing mode 옵션 삭제

### 주요 작업사항
**화면 제스처를 탐지하여 텍스트 및 음성 출력**
화면에 비치는 제스처를 탐지하여 텍스트를 출력합니다.
탐지한 텍스트는 배열에 담기며, 만약, 배열에 동일한 단어가 있는 경우 제외됩니다. (작은 제스처 데이터)

궁금한 점이 setState 내 if문을 처리해도 되는지, setState 밖에서 if문을 처리해도 되는지 고민입니다. 

```
              setWords((previous) => {
                if (previous.includes(WORD[hand1.name])) {
                  return [...previous];
                } else {
                  return [...previous, WORD[hand1.name]];
                }
              });
```

![image](https://user-images.githubusercontent.com/94096095/178434207-aca29818-fc35-4e06-97a8-13bea17b1bbc.png)


또한, 특정 제스처를 할 경우 text to speech API가 발동하여 배열의 text을 읽어줍니다.

```
  const handleWordsSpeech = (words) => {
    if (words.length) {
      speech.text = words;
      window.speechSynthesis.speak(speech);
    }
  };
```

**양손 제스처 등록**
현재 4가지의 제스처를 등록하였습니다.

1. hello : 안녕하세요
2. meet: 반갑습니다.
3. erase: 이전 텍스트 지우기
4. speech: text to speech API 함수 실행

추후 제스처를 조금 더 추가할 예정입니다.


**비디오 facing mode 옵션 삭제**
현재 얼굴을 비치는 웹캠만을 사용하고 있어 우선 비디오 facing mode에 대한 옵션을 삭제하였습니다. 

