### PR TITLE
[2022/07/13] 라우터 및 컴포넌트 명 수정, 비디오 및 캔버스 넓이 지정 및 webkit-playsinline 추가, 감지된 text를 추가하는 setWords에 throttle 함수 적용 및 추가 제스처 등록 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "jotai": "^1.7.4",
+        "lodash": "^4.17.21",
         "nanoid": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "jotai": "^1.7.4",
+    "lodash": "^4.17.21",
     "nanoid": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -9,10 +9,10 @@ import PracticeMain from "./pages/Practice/PracticeMain";
 import PracticeDetail from "./pages/Practice/PracticeDetail";
 import TestDetail from "./pages/Practice/TestDetail";
 import TestResult from "./pages/Practice/TestResult";
-import Communication from "./pages/Communication";
-import CommunicationMain from "./pages/Communication/CommunicationMain";
-import SelfGesture from "./pages/Communication/SelfGesture";
-import HandGesture from "./pages/Communication/HandGesture";
+import Gesture from "./pages/Gesture";
+import GestureMain from "./pages/Gesture/GestureMain";
+import SelfGesture from "./pages/Gesture/SelfGesture";
+import HandGesture from "./pages/Gesture/HandGesture";
 
 function App() {
   return (
@@ -26,10 +26,10 @@ function App() {
           <Route path="detail/:id/test" element={<TestDetail />} />
           <Route path="detail/:id/test/result" element={<TestResult />} />
         </Route>
-        <Route path="/communication" element={<Communication />}>
-          <Route index element={<CommunicationMain />} />
-          <Route path="selfgesture" element={<SelfGesture />} />
+        <Route path="/gesture" element={<Gesture />}>
+          <Route index element={<GestureMain />} />
           <Route path="handgesture" element={<HandGesture />} />
+          <Route path="selfgesture" element={<SelfGesture />} />
         </Route>
       </Routes>
     </Wrapper>

--- a/src/common/Fingerpose/Gestures/words/Appreciate.js
+++ b/src/common/Fingerpose/Gestures/words/Appreciate.js
@@ -1,0 +1,38 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const appreciate = new GestureDescription("appreciate");
+
+// thumb:
+appreciate.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+appreciate.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+for (let finger of [Finger.Index, Finger.Middle, Finger.Ring, Finger.Pinky]) {
+  appreciate.addCurl(Handedness.Left, finger, FingerCurl.NoCurl, 1.0);
+  appreciate.addCurl(Handedness.Left, finger, FingerCurl.HalfCurl, 0.8);
+  appreciate.addDirection(
+    Handedness.Left,
+    finger,
+    FingerDirection[FingerAxis.XY].HorizontalRight,
+    0.8,
+  );
+
+  appreciate.addCurl(Handedness.Right, finger, FingerCurl.NoCurl, 1.0);
+  appreciate.addCurl(Handedness.Right, finger, FingerCurl.HalfCurl, 0.8);
+
+  appreciate.addDirection(
+    Handedness.Right,
+    finger,
+    FingerDirection[FingerAxis.XY].HorizontalLeft,
+    0.8,
+  );
+}
+
+export default appreciate;

--- a/src/common/Fingerpose/Gestures/words/Come.js
+++ b/src/common/Fingerpose/Gestures/words/Come.js
@@ -1,0 +1,39 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const come = new GestureDescription("come");
+
+come.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+
+come.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.HalfCurl,
+  1.0,
+  HandSide.Back,
+);
+come.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+for (let finger of [Finger.Middle, Finger.Ring, Finger.Pinky]) {
+  come.addCurl(Handedness.Left, finger, FingerCurl.FullCurl, 1.0);
+  come.addDirection(
+    Handedness.Left,
+    finger,
+    FingerDirection[FingerAxis.XY].DiagonalUpRight,
+    0.8,
+  );
+}
+
+export default come;

--- a/src/common/Fingerpose/Gestures/words/Hello.js
+++ b/src/common/Fingerpose/Gestures/words/Hello.js
@@ -27,7 +27,6 @@ hello.addDirection(
 
 // index:
 hello.addCurl(Handedness.Left, Finger.Index, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Left, Finger.Index, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Left,
   Finger.Index,
@@ -43,7 +42,6 @@ hello.addDirection(
 
 // middle:
 hello.addCurl(Handedness.Left, Finger.Middle, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Left, Finger.Middle, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Left,
   Finger.Middle,
@@ -59,7 +57,6 @@ hello.addDirection(
 
 // ring:
 hello.addCurl(Handedness.Left, Finger.Ring, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Left, Finger.Ring, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Left,
   Finger.Ring,
@@ -75,7 +72,6 @@ hello.addDirection(
 
 // pinky:
 hello.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Left,
   Finger.Pinky,
@@ -105,7 +101,6 @@ hello.addDirection(
 
 // index:
 hello.addCurl(Handedness.Right, Finger.Index, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Right, Finger.Index, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Right,
   Finger.Index,
@@ -121,7 +116,6 @@ hello.addDirection(
 
 // middle:
 hello.addCurl(Handedness.Right, Finger.Middle, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Right, Finger.Middle, FingerCurl.HalfCurl, 0.8);
 hello.addDirection(
   Handedness.Right,
   Finger.Middle,
@@ -137,7 +131,6 @@ hello.addDirection(
 
 // ring:
 hello.addCurl(Handedness.Right, Finger.Ring, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Right, Finger.Ring, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Right,
   Finger.Ring,
@@ -153,7 +146,6 @@ hello.addDirection(
 
 // pinky:
 hello.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.FullCurl, 1.0);
-hello.addCurl(Handedness.Right, Finger.Pinky, FingerCurl.HalfCurl, 0.9);
 hello.addDirection(
   Handedness.Right,
   Finger.Pinky,

--- a/src/common/Fingerpose/Gestures/words/Love.js
+++ b/src/common/Fingerpose/Gestures/words/Love.js
@@ -1,0 +1,47 @@
+import {
+  Handedness,
+  Finger,
+  FingerCurl,
+  FingerDirection,
+  HandSide,
+  FingerAxis,
+} from "../../FingerDescription";
+import GestureDescription from "../../GestureDescription";
+
+const love = new GestureDescription("love");
+
+love.addCurl(Handedness.Left, Finger.Thumb, FingerCurl.NoCurl, 1.0);
+love.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].HorizontalRight,
+  0.8,
+);
+
+love.addCurl(
+  Handedness.Left,
+  Finger.Index,
+  FingerCurl.NoCurl,
+  1.0,
+  HandSide.Palm,
+);
+love.addDirection(
+  Handedness.Left,
+  Finger.Index,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+for (let finger of [Finger.Middle, Finger.Ring]) {
+  love.addCurl(Handedness.Left, finger, FingerCurl.FullCurl, 1.0);
+}
+
+love.addCurl(Handedness.Left, Finger.Pinky, FingerCurl.NoCurl, 1.0);
+love.addDirection(
+  Handedness.Left,
+  Finger.Pinky,
+  FingerDirection[FingerAxis.XY].VerticalUp,
+  0.8,
+);
+
+export default love;

--- a/src/common/Fingerpose/Gestures/words/Speech.js
+++ b/src/common/Fingerpose/Gestures/words/Speech.js
@@ -11,7 +11,6 @@ import GestureDescription from "../../GestureDescription";
 const speech = new GestureDescription("speech");
 
 speech.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.NoCurl, 1.0);
-speech.addCurl(Handedness.Right, Finger.Thumb, FingerCurl.HalfCurl, 0.8);
 speech.addDirection(
   Handedness.Right,
   Finger.Thumb,
@@ -34,12 +33,6 @@ speech.addDirection(
 );
 
 speech.addCurl(Handedness.Right, Finger.Middle, FingerCurl.NoCurl, 1.0);
-speech.addDirection(
-  Handedness.Right,
-  Finger.Middle,
-  FingerDirection[FingerAxis.XY].VerticalUp,
-  0.8,
-);
 
 speech.addCurl(Handedness.Right, Finger.Ring, FingerCurl.NoCurl, 1.0);
 

--- a/src/common/Fingerpose/Gestures/words/index.js
+++ b/src/common/Fingerpose/Gestures/words/index.js
@@ -2,7 +2,10 @@ import hello from "./Hello";
 import erase from "./Erase";
 import speech from "./Speech";
 import meet from "./Meet";
+import appreciate from "./Appreciate";
+import come from "./Come";
+import love from "./Love";
 
-const words = [hello, erase, speech, meet];
+const words = [hello, erase, speech, meet, appreciate, love, come];
 
 export default words;

--- a/src/components/atoms/Canvas.js
+++ b/src/components/atoms/Canvas.js
@@ -15,7 +15,7 @@ const StyledCanvas = styled.canvas`
   right: 0;
   text-align: center;
   z-index: 4;
-  width: auto;
+  width: 360px;
   height: auto;
 `;
 

--- a/src/components/atoms/Video.js
+++ b/src/components/atoms/Video.js
@@ -7,7 +7,6 @@ import { FACING_MODE } from "../../constants/webcam";
 
 function Video(props, ref) {
   const videoConfig = {
-    width: 360,
     facingMode: FACING_MODE.user,
   };
 
@@ -16,6 +15,7 @@ function Video(props, ref) {
       autoPlay
       muted
       playsInline
+      webkit-playsinline="true"
       videoConstraints={videoConfig}
       ref={ref}
     />
@@ -30,7 +30,7 @@ const StyledVideo = styled(Webcam)`
   right: 0;
   text-align: center;
   z-index: 2;
-  width: auto;
+  width: 360px;
   height: auto;
 `;
 

--- a/src/components/organisms/GestureListContent.js
+++ b/src/components/organisms/GestureListContent.js
@@ -1,19 +1,11 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
 import Text from "../atoms/Text";
 import Button from "../atoms/Button";
 
-function CommunicationContent({
-  title,
-  description,
-  buttonTitle,
-  page,
-  onClick,
-}) {
-  console.log();
+function GestureContent({ title, description, buttonTitle, page, onClick }) {
   return (
     <StyledContainer>
       <Wrapper>
@@ -27,7 +19,7 @@ function CommunicationContent({
   );
 }
 
-export default CommunicationContent;
+export default GestureContent;
 
 const StyledContainer = styled.div`
   display: flex;
@@ -46,7 +38,7 @@ const Wrapper = styled.div`
   height: 20vh;
 `;
 
-CommunicationContent.propTypes = {
+GestureContent.propTypes = {
   title: PropTypes.string,
   onClick: PropTypes.func,
   description: PropTypes.string,

--- a/src/components/organisms/MainContent.js
+++ b/src/components/organisms/MainContent.js
@@ -9,7 +9,6 @@ import Text from "../atoms/Text";
 import Button from "../atoms/Button";
 
 import logo from "../../assets/logo192.png";
-import congrats from "../../assets/congratulations.png";
 
 function MainContent() {
   const navigate = useNavigate();
@@ -25,7 +24,7 @@ function MainContent() {
 
   return (
     <StyledMainContent>
-      <Image width="40%" height="180px" alt="logo" src={congrats} />
+      <Image width="40%" height="180px" alt="logo" src={logo} />
       <Title color="black">수어지교(手語之交)</Title>
       <Wrapper>
         <Text color="black" className="normal">
@@ -48,7 +47,7 @@ function MainContent() {
           width="80vw"
           height="50px"
           className="normal"
-          onClick={() => moveToPage("communication")}
+          onClick={() => moveToPage("gesture")}
         >
           수어 인식하기
         </Button>

--- a/src/components/organisms/VideoContent.js
+++ b/src/components/organisms/VideoContent.js
@@ -1,15 +1,14 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
 import Video from "../atoms/Video";
 import Canvas from "../atoms/Canvas";
-import Button from "../atoms/Button";
 
-function VideoContent({ facingMode, webcamRef, canvasRef }) {
+function VideoContent({ webcamRef, canvasRef }) {
   return (
     <Container>
-      <Video facingMode={facingMode} ref={webcamRef} />
+      <Video ref={webcamRef} />
       <Canvas ref={canvasRef} />
     </Container>
   );
@@ -26,8 +25,6 @@ const Container = styled.div`
 `;
 
 VideoContent.propTypes = {
-  onClick: PropTypes.func,
-  facingMode: PropTypes.string,
   webcamRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.any }),

--- a/src/constants/word.js
+++ b/src/constants/word.js
@@ -1,6 +1,10 @@
 const WORD = {
   hello: "안녕하세요",
-  meet: "반갑습니다",
+  come: "와주셔서",
+  meet: "만나서",
+  glad: "반갑습니다",
+  appreciate: "감사합니다",
+  love: "I love you",
 };
 
 export default WORD;

--- a/src/pages/Gesture/GestureMain.js
+++ b/src/pages/Gesture/GestureMain.js
@@ -3,10 +3,10 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import HeaderContent from "../../components/organisms/HeaderContent";
-import CommunicationContent from "../../components/organisms/GestureListContent";
+import GestureContent from "../../components/organisms/GestureListContent";
 import { COMMUNICATION_LIST } from "../../constants/communication";
 
-function CommunicationMain() {
+function GestureMain() {
   const navigate = useNavigate();
 
   const moveToHome = () => {
@@ -14,7 +14,7 @@ function CommunicationMain() {
   };
 
   const moveToSubPage = (subPage) => {
-    navigate(`/communication/${subPage}`);
+    navigate(`/gesture/${subPage}`);
   };
 
   return (
@@ -22,18 +22,14 @@ function CommunicationMain() {
       <HeaderContent title="수어 인식하기" onClick={moveToHome} />
       <Wrapper>
         {COMMUNICATION_LIST.map((data) => (
-          <CommunicationContent
-            key={data.id}
-            onClick={moveToSubPage}
-            {...data}
-          />
+          <GestureContent key={data.id} onClick={moveToSubPage} {...data} />
         ))}
       </Wrapper>
     </Container>
   );
 }
 
-export default CommunicationMain;
+export default GestureMain;
 
 const Container = styled.div`
   display: flex;

--- a/src/pages/Gesture/SelfGesture.js
+++ b/src/pages/Gesture/SelfGesture.js
@@ -129,11 +129,11 @@ function SelfGesture() {
     console.log("Uploaded");
   };
 
-  const moveToCommunicationMain = async () => {
+  const moveToSubMain = async () => {
     await classifier.clearAllClasses();
 
     await classifier.dispose();
-    navigate("/communication");
+    navigate("/gesture");
   };
 
   useEffect(() => {
@@ -163,6 +163,7 @@ function SelfGesture() {
       timerId = setInterval(() => {
         runEstimator();
       }, 1000);
+
       console.log(timerId);
     }
 
@@ -171,7 +172,7 @@ function SelfGesture() {
 
   return (
     <Container>
-      <HeaderContent title="나만의 제스처" onClick={moveToCommunicationMain} />
+      <HeaderContent title="나만의 제스처" onClick={moveToSubMain} />
       <VideoWrapper>
         <Video ref={webcamRef} />
       </VideoWrapper>
@@ -181,7 +182,7 @@ function SelfGesture() {
           <StyledText ref={figures}></StyledText>
           <StyledText ref={probability}></StyledText>
         </TextWrapper>
-        <FormContent title="학습 제스처" onClick={addGesture} />
+        <FormContent onClick={addGesture} />
         <ListContainer>
           {gestureList.map((gesture) => (
             <ListWrapper key={gesture.id}>

--- a/src/pages/Gesture/index.js
+++ b/src/pages/Gesture/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 
-function Communication() {
+function Gesture() {
   return (
     <Container>
       <Outlet />
@@ -10,7 +10,7 @@ function Communication() {
   );
 }
 
-export default Communication;
+export default Gesture;
 
 const Container = styled.div`
   display: flex;

--- a/src/pages/Practice/PracticeDetail.js
+++ b/src/pages/Practice/PracticeDetail.js
@@ -21,19 +21,13 @@ import Text from "../../components/atoms/Text";
 import Button from "../../components/atoms/Button";
 
 import ImageOfLetters from "../../assets/image";
-import {
-  PRACTICE_TITLE,
-  PRACTICE_DETECTED,
-  FACING_MODE,
-  Letter,
-} from "../../constants";
+import { PRACTICE_TITLE, PRACTICE_DETECTED, Letter } from "../../constants";
 
 function PracticeDetail() {
   const webcamRef = useRef(null);
   const canvasRef = useRef(null);
   const params = useParams();
   const navigate = useNavigate();
-  const [facingMode, setFacingMode] = useState(FACING_MODE.user);
   const [score, setScore] = useState(0);
   const [result, setResult] = useState(PRACTICE_DETECTED.NONE);
   const [page, setPage] = useState(false);
@@ -48,19 +42,8 @@ function PracticeDetail() {
     engNameOfCurrentLetter,
   );
 
-  const moveToPracticeMain = () => {
+  const moveToSubMain = () => {
     navigate("/practice");
-  };
-
-  const handleFacingModeChange = () => {
-    switch (facingMode) {
-      case FACING_MODE.user:
-        setFacingMode(FACING_MODE.environment);
-        break;
-      case FACING_MODE.environment:
-        setFacingMode(FACING_MODE.user);
-        break;
-    }
   };
 
   const handleIndexIncrease = () => {
@@ -154,7 +137,7 @@ function PracticeDetail() {
 
   return (
     <Container>
-      <HeaderContent title="연습하기" onClick={moveToPracticeMain} />
+      <HeaderContent title="연습하기" onClick={moveToSubMain} />
       <Wrapper>
         <Button className="small" onClick={handleIndexDecrease}>
           이전 글자
@@ -163,12 +146,7 @@ function PracticeDetail() {
           다음 글자
         </Button>
       </Wrapper>
-      <VideoContent
-        onClick={handleFacingModeChange}
-        facingMode={facingMode}
-        webcamRef={webcamRef}
-        canvasRef={canvasRef}
-      />
+      <VideoContent webcamRef={webcamRef} canvasRef={canvasRef} />
       <Wrapper>
         <ImageBox>
           <Image

--- a/src/pages/Practice/TestDetail.js
+++ b/src/pages/Practice/TestDetail.js
@@ -22,19 +22,13 @@ import Text from "../../components/atoms/Text";
 import Button from "../../components/atoms/Button";
 
 import ImageOfLetters from "../../assets/image";
-import {
-  PRACTICE_TITLE,
-  FACING_MODE,
-  lengthOfLetter,
-  Letter,
-} from "../../constants";
+import { PRACTICE_TITLE, lengthOfLetter, Letter } from "../../constants";
 
 function TestDetail() {
   const webcamRef = useRef(null);
   const canvasRef = useRef(null);
   const params = useParams();
   const navigate = useNavigate();
-  const [facingMode, setFacingMode] = useState(FACING_MODE.user);
   const [detector, setDetector] = useState(false);
   const [indexOfRandom, increaseIndexOfRandom] = useAtom(handleIndexOfRandom);
   const [numOfCorrectAnswers, increaseNumOfCorrect] =
@@ -53,7 +47,7 @@ function TestDetail() {
     });
   };
 
-  const moveToPracticeMain = () => {
+  const moveToSubMain = () => {
     navigate("/practice");
   };
 
@@ -83,17 +77,6 @@ function TestDetail() {
   const handleTestInitialize = () => {
     initailizeTest();
     shuffleGestures(typeOfLetter);
-  };
-
-  const handleFacingModeChange = () => {
-    switch (facingMode) {
-      case FACING_MODE.user:
-        setFacingMode(FACING_MODE.environment);
-        break;
-      case FACING_MODE.environment:
-        setFacingMode(FACING_MODE.user);
-        break;
-    }
   };
 
   const detectHands = async (detector) => {
@@ -178,7 +161,7 @@ function TestDetail() {
 
   return (
     <Container>
-      <HeaderContent title="테스트하기" onClick={moveToPracticeMain} />
+      <HeaderContent title="테스트하기" onClick={moveToSubMain} />
       <Wrapper>
         <Button className="small" onClick={handleTestInitialize}>
           다시 하기
@@ -187,12 +170,7 @@ function TestDetail() {
           넘어가기
         </Button>
       </Wrapper>
-      <VideoContent
-        onClick={handleFacingModeChange}
-        facingMode={facingMode}
-        webcamRef={webcamRef}
-        canvasRef={canvasRef}
-      />
+      <VideoContent webcamRef={webcamRef} canvasRef={canvasRef} />
       <Wrapper>
         <ImageBox>
           {engNameOfCurrentLetter ? (


### PR DESCRIPTION
## 주제
- 라우터 및 컴포넌트 명 수정
- 비디오 및 캔버스 넓이 지정 및 webkit-playsinline 추가
- 감지된 text를 추가하는 setWords에 throttle 함수 적용
- 추가 제스처 등록

### 주요 작업사항
**라우터 및 컴포넌트 명 수정**
기존 communication이라는 이름이 페이지 기능과 어울리지 않는 것 같아 gesture로 수정하였습니다.

**비디오 및 캔버스 넓이 지정 및 webkit-playsinline 추가**
리액트 네이티브에 웹뷰를 설정하여 접속하니, selfGesture의 비디오 화면 크기가 모바일 사이즈에 적용되지 않고 커지다가
갑자기 꺼지는 현상이 발생했습니다.

심지어 로컬에서도 PC 사이즈 기준으로 사이즈가 커지고 있어, 우선 명시적으로 width를 360px로 지정하였습니다.
추가로 아이폰에서 페이지에 접속하면 웹캠이 full screen으로 재생됩니다. 
이를 방지하기 위해 우선  아래와 같이 webkit-playsinline="true"을 추가해 보았습니다. 

```javascript
    <StyledVideo
      autoPlay
      muted
      playsInline
      webkit-playsinline="true"
      videoConstraints={videoConfig}
      ref={ref}
    />

```

**감지된 text를 추가하는 setWords에 throttle 함수 적용**
setInterval에 의해 0.5초마다 detector 함수가 실행되어 화면에 비치는 제스처가 지속적으로 배열에 추가됩니다.
이를 방지하기 위해 throttle 함수를 적용하여 3초에 한 번만 실행될 수 있도록 적용해 보았습니다. 

```javascript
  const handleWordsSpeech = (words) => {
    if (words.length) {
      speech.text = words;
      window.speechSynthesis.speak(speech);
    }
  };
```

**추가 제스처 등록**
추가 제스처를 아래와 같이 등록하였습니다.

1. come: 와주셔서
2. appreciate: 감사합니다.
3. love: I love you
4. glad: 반갑습니다

추후 제스처를 조금 더 추가할 예정입니다.
